### PR TITLE
feat: split flavor response into basic and available types

### DIFF
--- a/internal/domain/compute/handler.go
+++ b/internal/domain/compute/handler.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"net/http"
+	"os"
 	"github.com/gin-gonic/gin"
 )
 
@@ -17,7 +18,7 @@ func NewHandler(svc *Service) *Handler {
 
 // GetFlavors 핸들러 함수
 func (h *Handler) GetFlavors(c *gin.Context) {
-	flavors, err := h.Svc.GetAvailableFlavors()
+	flavors, err := h.Svc.GetFlavors()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "사양 조회를 실패했습니다: " + err.Error()})
 		return
@@ -29,6 +30,27 @@ func (h *Handler) GetFlavors(c *gin.Context) {
 func (h *Handler) InitRoutes(rg *gin.RouterGroup) {
 	computeGroup := rg.Group("/compute") // /api/v1/compute
 	{
-		computeGroup.GET("/flavors", h.GetFlavors)
+		// 전체 flavors 조회
+		computeGroup.GET("/flavors/all", h.GetFlavors)
+		// 남은 자원량 기반 가용 flavors 조회
+		computeGroup.GET("/flavors/available", h.GetAvailableFlavors)
 	}
+}
+
+func (h *Handler) GetAvailableFlavors(c *gin.Context) {
+    // 인프라 레이어를 직접 안 부르고 Service(또는 Repo)를 거칩니다.
+    client, err := h.Svc.GetComputeClient() 
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": "Cloud connection failed"})
+        return
+    }
+
+    projectID := os.Getenv("OS_PROJECT_ID")
+
+    flavors, err := h.Svc.GetAvailableFlavorsWithLimit(client, projectID)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+        return
+    }
+    c.JSON(http.StatusOK, flavors)
 }

--- a/internal/domain/compute/repository.go
+++ b/internal/domain/compute/repository.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 )
 
@@ -14,23 +15,34 @@ func NewRepository(client *gophercloud.ProviderClient) *Repository {
 	return &Repository{Client: client}
 }
 
-// FetchFlavors는 미니PC 오픈스택 API를 호출하여 실제 사양 목록을 가져옵니다.
-func (r *Repository) FetchFlavors() ([]flavors.Flavor, error) {
-	// 1. Compute(Nova) 서비스 클라이언트 생성
-	// admin.rc에 있던 RegionOne을 명시해줍니다.
-	client, err := openstack.NewComputeV2(r.Client, gophercloud.EndpointOpts{
+// GetComputeClient - 외부 패키지 안 쓰고 리포지토리 자체 클라이언트로 서비스 클라이언트 생성
+func (r *Repository) GetComputeClient() (*gophercloud.ServiceClient, error) {
+	// 리포지토리가 들고 있는 r.Client(Provider)를 사용해서 바로 생성합니다.
+	return openstack.NewComputeV2(r.Client, gophercloud.EndpointOpts{
 		Region: "RegionOne",
 	})
+}
+
+// FetchFlavors - 여기서도 직접 r.GetComputeClient()를 호출해서 쓰면 중복 코드 줄어듭니다.
+func (r *Repository) FetchFlavors() ([]flavors.Flavor, error) {
+	client, err := r.GetComputeClient() // 방금 위에서 만든 함수 활용
 	if err != nil {
 		return nil, err
 	}
 
-	// 2. 상세 사양(vCPU, RAM, Disk 등)이 포함된 Flavor 목록 조회
 	allPages, err := flavors.ListDetail(client, nil).AllPages()
 	if err != nil {
 		return nil, err
 	}
 
-	// 3. 페이지 형태의 데이터를 슬라이스([]Flavor)로 추출
 	return flavors.ExtractFlavors(allPages)
+}
+
+// GetComputeQuota - 서비스 클라이언트를 인자로 받아서 쿼터 상세 정보 조회
+func (r *Repository) GetComputeQuota(client *gophercloud.ServiceClient, projectID string) (*quotasets.QuotaDetailSet, error) {
+	detail, err := quotasets.GetDetail(client, projectID).Extract()
+	if err != nil {
+		return nil, err
+	}
+	return &detail, nil
 }

--- a/internal/domain/compute/service.go
+++ b/internal/domain/compute/service.go
@@ -1,5 +1,10 @@
 package compute
 
+import (
+	"fmt"
+	"github.com/gophercloud/gophercloud"
+)
+
 // Service는 비즈니스 로직을 담당합니다.
 type Service struct {
 	Repo *Repository
@@ -10,8 +15,8 @@ func NewService(repo *Repository) *Service {
 	return &Service{Repo: repo}
 }
 
-// GetAvailableFlavors는 Repo에서 가져온 데이터를 우리 규격(FlavorResponse)으로 변환합니다.
-func (s *Service) GetAvailableFlavors() ([]FlavorResponse, error) {
+// GetFlavors는 Repo에서 가져온 데이터를 우리 규격(FlavorResponse)으로 변환합니다.
+func (s *Service) GetFlavors() ([]FlavorResponse, error) {
 	rawFlavors, err := s.Repo.FetchFlavors()
 	if err != nil {
 		return nil, err
@@ -28,4 +33,74 @@ func (s *Service) GetAvailableFlavors() ([]FlavorResponse, error) {
 		})
 	}
 	return res, nil
+}
+
+// GetAvailableFlavorsWithLimit 는 남은 자원량을 계산하여 각 Flavor별 가용 대수를 포함해 반환합니다.
+func (s *Service) GetAvailableFlavorsWithLimit(client *gophercloud.ServiceClient, projectID string) ([]AvailableFlavorResponse, error) {
+    // 1. 전체 Flavor 목록 가져오기
+    rawFlavors, err := s.Repo.FetchFlavors()
+    if err != nil {
+        return nil, err
+    }
+
+    // 2. Repo를 통해 상세 쿼터(Detail) 가져오기
+    quota, err := s.Repo.GetComputeQuota(client, projectID)
+    if err != nil {
+        return nil, fmt.Errorf("쿼터 조회 실패: %v", err)
+    }
+
+    // 3. 남은 자원 계산 (구조체 접근 방식 수정)
+    // QuotaDetailSet은 Cores.Limit, Cores.InUse 식으로 되어 있습니다.
+    remCores := quota.Cores.Limit - quota.Cores.InUse
+    remRAM := quota.RAM.Limit - quota.RAM.InUse
+    remInstances := quota.Instances.Limit - quota.Instances.InUse
+
+    var res []AvailableFlavorResponse
+    for _, f := range rawFlavors {
+        // vCPU 기준 가용 대수
+        countByCPU := 0
+        if f.VCPUs > 0 {
+            countByCPU = remCores / f.VCPUs
+        } else {
+            countByCPU = 999 // vCPU가 0인 경우(거의 없지만) 예외 처리
+        }
+
+        // RAM 기준 가용 대수
+        countByRAM := 0
+        if f.RAM > 0 {
+            countByRAM = remRAM / f.RAM
+        } else {
+            countByRAM = 999
+        }
+
+        // 4. 세 가지 제약(CPU, RAM, 총 Instance 개수) 중 가장 작은 값이 진짜 한도
+        maxPossible := countByCPU
+        if countByRAM < maxPossible {
+            maxPossible = countByRAM
+        }
+        if remInstances < maxPossible {
+            maxPossible = remInstances
+        }
+
+        // 결과가 마이너스면 0으로 세팅
+        if maxPossible < 0 {
+            maxPossible = 0
+        }
+
+        res = append(res, AvailableFlavorResponse{
+            FlavorResponse: FlavorResponse{
+                ID:    f.ID,
+                Name:  f.Name,
+                VCPUs: f.VCPUs,
+                RAM:   f.RAM,
+                Disk:  f.Disk,
+            },
+            MaxConfigurable: maxPossible,
+        })
+    }
+    return res, nil
+}
+
+func (s *Service) GetComputeClient() (*gophercloud.ServiceClient, error) {
+    return s.Repo.GetComputeClient()
 }

--- a/internal/domain/compute/types.go
+++ b/internal/domain/compute/types.go
@@ -1,10 +1,16 @@
 package compute
 
-// FlavorResponse는 프론트엔드에 전달할 사양 정보
+// 기본 정보 (all 용)
 type FlavorResponse struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	VCPUs int    `json:"vcpus"`
-	RAM   int    `json:"ram"`  // MB 단위
-	Disk  int    `json:"disk"` // GB 단위
+    ID    string `json:"id"`
+    Name  string `json:"name"`
+    VCPUs int    `json:"vcpus"`
+    RAM   int    `json:"ram"`
+    Disk  int    `json:"disk"`
+}
+
+// 계산 정보 포함 (available 용) - 상속(Embedding) 활용
+type AvailableFlavorResponse struct {
+    FlavorResponse
+    MaxConfigurable int `json:"max_configurable"`
 }


### PR DESCRIPTION
🚀 Title: feat: Flavor 조회 API 고도화 및 가용 자원 계산 로직 분리

📝 Description
기존에 하나로 관리되던 Flavor 응답 구조를 목적에 맞게 **전체 목록(all)**과 **가용 자원 포함 목록(available)**으로 분리하였습니다. 또한, Gophercloud SDK의 버전 업데이트에 따른 패키지 경로 이슈를 해결하고, Repository 레이어에서 OpenStack Client를 직접 관리하도록 아키텍처를 개선했습니다.

🛠️ Key Changes
Response 구조체 분리:

FlavorResponse: ID, Name, CPU, RAM 등 기본 사양 정보 제공 (전체 목록용)

AvailableFlavorResponse: 기존 정보에 MaxConfigurable(계산된 가용 대수) 필드 추가 (가용 목록용)

계산 로직 최적화:

OpenStack Quota Detail API를 사용하여 Limit과 InUse를 정확히 계산.

Cores, RAM, Instances 세 가지 제약 사항 중 가장 적은 값을 기준으로 가용 대수 산출.

의존성 및 아키텍처 개선:

gophercloud v1.14.1 패키지 경로 이슈 해결 (extensions/quotasets 적용).

infrastructure 패키지 중복 의존성을 제거하고 Repository에서 ProviderClient를 통해 직접 ServiceClient를 생성하도록 변경.

🧪 Test Result (cURL)
GET /flavors/all: max_configurable 필드 없이 순수 사양 정보만 반환 확인.

GET /flavors/available: 현재 쿼터 잔여량에 따른 정확한 가용 대수 반환 확인 (예: m1.tiny -> 33대 등).