### PR TITLE
refactor: README 구조 중심 개편 및 도메인 상세 설명 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,116 @@
-RCP-Server (Return Cloud Platform)
-학술동아리 RETURN의 클라우드 관리 플랫폼 백엔드 서버입니다.
+# RCP-Server (Return Cloud Platform)
 
-📁 Project Structure & Convention
-프로젝트의 일관성을 위해 다음과 같은 디렉토리 구조 및 명명 규칙을 따릅니다.
+학술동아리 RETURN의 클라우드 관리 플랫폼 백엔드 서버입니다.  
+현재 README는 프로젝트의 구조와 개발 규칙을 중심으로 설명하며, 도메인별 상세 구현 내용은 추후 별도로 정리할 예정입니다.
 
-📍 Directory Layout
-cmd/api/: 애플리케이션 진입점 및 Gin 라우터 초기화
+## Project Structure & Convention
 
-internal/: 외부에서 접근 불가능한 비즈니스 로직
+프로젝트는 진입점, 서버 조립, 도메인 로직, 외부 인프라 연동을 분리하는 구조로 작성되어 있습니다.
 
-domain/: 도메인 중심 설계(DDD)에 기반한 서비스 단위 분리
+### Directory Layout
 
-{domain_name}/: 각 서비스 도메인 (예: compute, network, storage)
+```text
+.
+|-- cmd/
+|   `-- api/
+|       `-- main.go
+|-- internal/
+|   |-- domain/
+|   |   `-- compute/
+|   |       |-- handler.go
+|   |       |-- init.go
+|   |       |-- repository.go
+|   |       |-- service.go
+|   |       `-- types.go
+|   |-- infrastructure/
+|   |   |-- http/
+|   |   |   `-- client.go
+|   |   `-- openstack/
+|   |       `-- client.go
+|   `-- server/
+|       |-- app.go
+|       `-- router.go
+|-- go.mod
+`-- go.sum
+```
 
-handler.go: API 엔드포인트 및 요청 핸들링 (Gin)
+### Directory Roles
 
-service.go: 핵심 비즈니스 로직 및 인터페이스 정의
+| 경로 | 역할 |
+|------|------|
+| `cmd/api/` | 애플리케이션 진입점입니다. 환경 변수를 읽고 서버를 실행합니다. |
+| `internal/server/` | 애플리케이션 조립과 공통 라우팅을 담당합니다. |
+| `internal/domain/compute/` | 도메인 단위 구현이 위치하는 예시 디렉터리입니다. |
+| `internal/infrastructure/openstack/` | OpenStack 인증용 ProviderClient를 생성합니다. |
+| `internal/infrastructure/http/` | Cloudflare Access 헤더를 주입하는 HTTP 클라이언트를 제공합니다. |
 
-repository.go: 데이터 소스 접근 로직 (Ent)
+### Domain File Convention
 
-pkg/: 프로젝트 전반에서 재사용 가능한 유틸리티 라이브러리
+`internal/domain/{domain}` 아래 파일은 다음 역할로 나뉩니다.
 
-configs/: 환경 설정 파일 (.yaml, .env)
+| 파일 | 역할 |
+|------|------|
+| `handler.go` | HTTP 요청/응답 처리 |
+| `service.go` | 도메인 비즈니스 로직 |
+| `repository.go` | 외부 데이터 소스 접근 |
+| `types.go` | 응답/전달용 타입 정의 |
+| `init.go` | 저장소, 서비스, 핸들러 조립 |
 
-api/: API 명세서 (Swagger/OpenAPI)
+## Application Flow
 
-📏 Development Rules
-새로운 기능 추가 시 internal/domain/{service} 하위에 구현하는 것을 원칙으로 합니다.
+현재 애플리케이션의 기본 흐름은 다음과 같습니다.
 
-도메인 간의 의존성은 인터페이스를 통해 결합도를 낮춥니다.
+1. `cmd/api/main.go`에서 `.env`를 로드하고 애플리케이션 실행 준비를 합니다.
+2. `internal/infrastructure/openstack/`에서 외부 인프라 클라이언트를 생성합니다.
+3. `internal/server/`에서 앱 의존성을 조립하고 라우터를 초기화합니다.
+4. 각 도메인은 `handler -> service -> repository` 흐름으로 요청을 처리합니다.
 
-🛠 Tech Stack & Versions
-🏁 Language & Runtime
-Go: 1.26.1 (darwin/arm64)
+## Development Rules
 
-🌍 Infrastructure (Core)
-OpenStack SDK: gophercloud/gophercloud v1.14.1
+- 새로운 기능은 원칙적으로 `internal/domain/{service}` 하위에 추가합니다.
+- HTTP 처리, 비즈니스 로직, 외부 연동 코드를 한 파일에 섞지 않습니다.
+- 도메인 간 결합이 필요할 경우 직접 구현을 참조하기보다 인터페이스나 조립 계층을 통해 연결하는 방향을 우선합니다.
+- README에는 계획 중인 스택보다 현재 저장소에 실제로 존재하는 구현을 기준으로 기록합니다.
 
-Web Framework: gin-gonic/gin v1.12.0
+## Tech Stack
 
-Database (ORM): entgo.io/ent v0.14.5 (Schema-first)
+현재 코드와 `go.mod` 기준 핵심 스택은 다음과 같습니다.
 
-Task Queue: hibiken/asynq v0.26.0 (Redis-based)
+| 항목 | 사용 기술 |
+|------|-----------|
+| Language | Go 1.26.1 |
+| Web Framework | `gin-gonic/gin` |
+| OpenStack SDK | `gophercloud/gophercloud` |
+| Env Loader | `joho/godotenv` |
 
-🔐 Security & Communication
-Auth: golang-jwt/jwt/v5 v5.3.1
+## Environment Variables
 
-Real-time: gorilla/websocket v1.5.3
+| 변수 | 설명 |
+|------|------|
+| `PORT` | 서버 포트. 비어 있으면 `8080`을 사용합니다. |
+| `OS_AUTH_URL` | OpenStack Identity 엔드포인트 |
+| `OS_USERNAME` | OpenStack 사용자 이름 |
+| `OS_PASSWORD` | OpenStack 비밀번호 |
+| `OS_PROJECT_NAME` | OpenStack 프로젝트 이름 |
+| `OS_USER_DOMAIN_NAME` | OpenStack 사용자 도메인 이름 |
+| `CF_ACCESS_CLIENT_ID` | Cloudflare Access Client ID |
+| `CF_ACCESS_CLIENT_SECRET` | Cloudflare Access Client Secret |
 
-Policy: casbin/casbin (RBAC - To be implemented)
+## Run
 
-📊 Observability & Tools
-Logging: uber-go/zap (Structured Logging)
+환경 변수를 준비한 뒤 아래 명령으로 실행합니다.
 
-Config: spf13/viper v1.21.0
+```bash
+go run ./cmd/api
+```
 
-Lint: golangci-lint
+기본 주소는 `http://localhost:8080`입니다.
+
+## Domain Documentation
+
+도메인별 API, 요청/응답 예시, 세부 비즈니스 규칙은 구현이 더 정리된 뒤 별도 섹션 또는 문서로 추가할 예정입니다.
+
+## Notes
+
+- OpenStack 호출은 Cloudflare Access 헤더가 포함된 HTTP 클라이언트를 통해 수행됩니다.
+- 아직 테스트 코드는 없고, 현재 검증은 `go test ./...` 수준의 컴파일 검증에 가깝습니다.


### PR DESCRIPTION
## 개요
프로젝트 README를 현재 저장소의 구조와 개발 규칙 중심으로 정리했습니다.  
특정 도메인에 종속된 상세 구현 설명은 제외하고, 추후 별도 문서 또는 섹션으로 확장할 수 있도록 문서 방향을 정돈했습니다.

## 변경 사항
- README를 프로젝트 구조와 공통 규칙 중심으로 재작성
- 디렉터리 레이아웃과 각 경로의 역할을 표 형태로 정리
- 도메인 디렉터리 내부 파일 규칙(`handler`, `service`, `repository`, `types`, `init`) 명시
- 애플리케이션의 공통 실행 흐름을 단계별로 정리
- 현재 코드 기준 핵심 기술 스택과 환경 변수 목록 정리
- 특정 도메인 API, 요청/응답 예시, 세부 비즈니스 규칙은 README에서 제외
- 도메인별 상세 내용은 추후 별도 문서화 예정임을 명시

## 기대 효과
- 프로젝트를 처음 보는 사람이 전체 구조를 더 빠르게 이해할 수 있음
- README가 특정 구현 상세에 과하게 묶이지 않아 유지보수가 쉬워짐
- 도메인 문서와 공통 문서를 분리할 수 있는 기반을 마련함

## 테스트
- 문서 수정 사항만 포함
- 코드 동작 변경 없음

## 참고
- 도메인별 API 및 상세 비즈니스 규칙은 추후 별도 문서 또는 README 섹션으로 추가 예정
