### PR TITLE
feat(ns-proxy): floating IP 없이 tenant 망 접근하는 SOCKS5 프록시

### DIFF
--- a/cmd/ns-proxy/allowlist.go
+++ b/cmd/ns-proxy/allowlist.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// Allowlist holds a set of CIDR networks that destinations must match.
+type Allowlist struct {
+	cidrs []*net.IPNet
+}
+
+// ParseCIDRs parses a comma-separated CIDR list. An empty or whitespace-only
+// spec is rejected (fail closed: empty must not silently allow everything).
+func ParseCIDRs(spec string) (*Allowlist, error) {
+	if strings.TrimSpace(spec) == "" {
+		return nil, fmt.Errorf("CIDR spec is empty (fail closed)")
+	}
+	parts := strings.Split(spec, ",")
+	cidrs := make([]*net.IPNet, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed == "" {
+			return nil, fmt.Errorf("empty CIDR entry in spec %q", spec)
+		}
+		_, n, err := net.ParseCIDR(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR %q: %w", trimmed, err)
+		}
+		cidrs = append(cidrs, n)
+	}
+	return &Allowlist{cidrs: cidrs}, nil
+}
+
+// Contains returns true when ip falls inside any of the allowed networks.
+func (a *Allowlist) Contains(ip net.IP) bool {
+	for _, n := range a.cidrs {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/ns-proxy/allowlist.go
+++ b/cmd/ns-proxy/allowlist.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 )
 
-// Allowlist holds a set of CIDR networks that destinations must match.
+// Allowlist는 목적지가 매치해야 하는 CIDR 집합.
 type Allowlist struct {
 	cidrs []*net.IPNet
 }
 
-// ParseCIDRs parses a comma-separated CIDR list. An empty or whitespace-only
-// spec is rejected (fail closed: empty must not silently allow everything).
+// ParseCIDRs는 콤마 구분 CIDR 리스트를 파싱. 빈/공백 spec은 거부
+// (fail closed: 빈 값을 "모두 허용"으로 해석하면 안 됨).
 func ParseCIDRs(spec string) (*Allowlist, error) {
 	if strings.TrimSpace(spec) == "" {
 		return nil, fmt.Errorf("CIDR spec is empty (fail closed)")
@@ -33,7 +33,7 @@ func ParseCIDRs(spec string) (*Allowlist, error) {
 	return &Allowlist{cidrs: cidrs}, nil
 }
 
-// Contains returns true when ip falls inside any of the allowed networks.
+// Contains는 ip가 허용 네트워크 중 하나에 속하면 true.
 func (a *Allowlist) Contains(ip net.IP) bool {
 	for _, n := range a.cidrs {
 		if n.Contains(ip) {

--- a/cmd/ns-proxy/allowlist_test.go
+++ b/cmd/ns-proxy/allowlist_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+func TestParseCIDRs_RejectsEmpty(t *testing.T) {
+	if _, err := ParseCIDRs(""); err == nil {
+		t.Fatal("expected error for empty spec, got nil")
+	}
+	if _, err := ParseCIDRs("   "); err == nil {
+		t.Fatal("expected error for whitespace spec, got nil")
+	}
+}
+
+func TestParseCIDRs_RejectsInvalid(t *testing.T) {
+	if _, err := ParseCIDRs("not-a-cidr"); err == nil {
+		t.Fatal("expected error for garbage, got nil")
+	}
+	if _, err := ParseCIDRs("192.168.0.0/16,bad/24"); err == nil {
+		t.Fatal("expected error when one entry invalid, got nil")
+	}
+}
+
+func TestParseCIDRs_RejectsEmptyEntries(t *testing.T) {
+	cases := []string{
+		"192.168.0.0/16,",
+		",10.0.0.0/8",
+		"192.168.0.0/16,,10.0.0.0/8",
+		"  ,  ,  ",
+	}
+	for _, spec := range cases {
+		if _, err := ParseCIDRs(spec); err == nil {
+			t.Errorf("ParseCIDRs(%q) should error, got nil", spec)
+		}
+	}
+}
+
+func TestAllowlist_ContainsSingleCIDR(t *testing.T) {
+	a, err := ParseCIDRs("192.168.0.0/16")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ip1 := net.ParseIP("192.168.1.10")
+	if ip1 == nil {
+		t.Fatal("test bug: net.ParseIP(\"192.168.1.10\") returned nil")
+	}
+	if !a.Contains(ip1) {
+		t.Error("expected 192.168.1.10 to match 192.168.0.0/16")
+	}
+	ip2 := net.ParseIP("10.0.0.1")
+	if ip2 == nil {
+		t.Fatal("test bug: net.ParseIP(\"10.0.0.1\") returned nil")
+	}
+	if a.Contains(ip2) {
+		t.Error("did not expect 10.0.0.1 to match 192.168.0.0/16")
+	}
+}
+
+func TestAllowlist_ContainsMultipleCIDRs(t *testing.T) {
+	a, err := ParseCIDRs("192.168.0.0/16, 10.42.0.0/24")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cases := []struct {
+		ip      string
+		allowed bool
+	}{
+		{"192.168.5.5", true},
+		{"10.42.0.99", true},
+		{"10.43.0.1", false},
+		{"172.16.0.1", false},
+	}
+	for _, c := range cases {
+		ip := net.ParseIP(c.ip)
+		if ip == nil {
+			t.Fatalf("test bug: net.ParseIP(%q) returned nil", c.ip)
+		}
+		got := a.Contains(ip)
+		if got != c.allowed {
+			t.Errorf("Contains(%s) = %v, want %v", c.ip, got, c.allowed)
+		}
+	}
+}

--- a/cmd/ns-proxy/config.go
+++ b/cmd/ns-proxy/config.go
@@ -57,13 +57,6 @@ func LoadConfig(getenv func(string) string) (*Config, error) {
 	}, nil
 }
 
-func envString(get func(string) string, key, def string) string {
-	if v := get(key); v != "" {
-		return v
-	}
-	return def
-}
-
 func envInt(get func(string) string, key string, def int) (int, error) {
 	v := get(key)
 	if v == "" {

--- a/cmd/ns-proxy/config.go
+++ b/cmd/ns-proxy/config.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	SockPath      string
+	AllowList     *Allowlist
+	MaxConns      int
+	DialTimeout   time.Duration
+	ShutdownGrace time.Duration
+	LogLevel      string
+}
+
+// LoadConfig reads configuration from a getenv function (typically os.Getenv).
+// The getenv parameter makes the function trivially testable.
+func LoadConfig(getenv func(string) string) (*Config, error) {
+	al, err := ParseCIDRs(getenv("RCP_NS_PROXY_ALLOW_CIDR"))
+	if err != nil {
+		return nil, fmt.Errorf("RCP_NS_PROXY_ALLOW_CIDR: %w", err)
+	}
+	maxConns, err := envInt(getenv, "RCP_NS_PROXY_MAX_CONNS", 1024)
+	if err != nil {
+		return nil, err
+	}
+	if maxConns <= 0 {
+		return nil, fmt.Errorf("RCP_NS_PROXY_MAX_CONNS: must be positive, got %d", maxConns)
+	}
+	dialTimeout, err := envPositiveDuration(getenv, "RCP_NS_PROXY_DIAL_TIMEOUT", 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	grace, err := envPositiveDuration(getenv, "RCP_NS_PROXY_SHUTDOWN_GRACE", 30*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	sockPath, err := envSockPath(getenv, "RCP_NS_PROXY_SOCK", "/run/rcp/ns-proxy.sock")
+	if err != nil {
+		return nil, err
+	}
+	logLevel, err := envLogLevel(getenv, "RCP_NS_PROXY_LOG_LEVEL", "info")
+	if err != nil {
+		return nil, err
+	}
+	return &Config{
+		SockPath:      sockPath,
+		AllowList:     al,
+		MaxConns:      maxConns,
+		DialTimeout:   dialTimeout,
+		ShutdownGrace: grace,
+		LogLevel:      logLevel,
+	}, nil
+}
+
+func envString(get func(string) string, key, def string) string {
+	if v := get(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(get func(string) string, key string, def int) (int, error) {
+	v := get(key)
+	if v == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", key, err)
+	}
+	return n, nil
+}
+
+func envDuration(get func(string) string, key string, def time.Duration) (time.Duration, error) {
+	v := get(key)
+	if v == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", key, err)
+	}
+	return d, nil
+}
+
+func envPositiveDuration(get func(string) string, key string, def time.Duration) (time.Duration, error) {
+	d, err := envDuration(get, key, def)
+	if err != nil {
+		return 0, err
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s: must be > 0, got %v", key, d)
+	}
+	return d, nil
+}
+
+func envSockPath(get func(string) string, key, def string) (string, error) {
+	raw := get(key)
+	v := strings.TrimSpace(raw)
+	if raw != "" && v == "" {
+		// env var was set but contained only whitespace
+		return "", fmt.Errorf("%s: must be an absolute path, got %q", key, raw)
+	}
+	if v == "" {
+		v = def
+	}
+	if !filepath.IsAbs(v) {
+		return "", fmt.Errorf("%s: must be an absolute path, got %q", key, v)
+	}
+	return v, nil
+}
+
+func envLogLevel(get func(string) string, key, def string) (string, error) {
+	v := strings.ToLower(strings.TrimSpace(get(key)))
+	if v == "" {
+		return def, nil
+	}
+	switch v {
+	case "debug", "info", "warn", "error":
+		return v, nil
+	default:
+		return "", fmt.Errorf("%s: invalid log level %q (allowed: debug, info, warn, error)", key, v)
+	}
+}

--- a/cmd/ns-proxy/config.go
+++ b/cmd/ns-proxy/config.go
@@ -17,8 +17,8 @@ type Config struct {
 	LogLevel      string
 }
 
-// LoadConfig reads configuration from a getenv function (typically os.Getenv).
-// The getenv parameter makes the function trivially testable.
+// LoadConfig는 getenv 함수(보통 os.Getenv)에서 설정을 읽는다.
+// getenv를 파라미터로 받아 테스트가 단순해짐.
 func LoadConfig(getenv func(string) string) (*Config, error) {
 	al, err := ParseCIDRs(getenv("RCP_NS_PROXY_ALLOW_CIDR"))
 	if err != nil {
@@ -96,7 +96,7 @@ func envSockPath(get func(string) string, key, def string) (string, error) {
 	raw := get(key)
 	v := strings.TrimSpace(raw)
 	if raw != "" && v == "" {
-		// env var was set but contained only whitespace
+		// 값은 설정됐지만 공백만 있는 경우.
 		return "", fmt.Errorf("%s: must be an absolute path, got %q", key, raw)
 	}
 	if v == "" {

--- a/cmd/ns-proxy/config_test.go
+++ b/cmd/ns-proxy/config_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func mapEnv(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestLoadConfig_DefaultsAndAllowCIDR(t *testing.T) {
+	cfg, err := LoadConfig(mapEnv(map[string]string{
+		"RCP_NS_PROXY_ALLOW_CIDR": "192.168.0.0/16",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SockPath != "/run/rcp/ns-proxy.sock" {
+		t.Errorf("SockPath default = %q", cfg.SockPath)
+	}
+	if cfg.MaxConns != 1024 {
+		t.Errorf("MaxConns default = %d", cfg.MaxConns)
+	}
+	if cfg.DialTimeout != 5*time.Second {
+		t.Errorf("DialTimeout default = %v", cfg.DialTimeout)
+	}
+	if cfg.ShutdownGrace != 30*time.Second {
+		t.Errorf("ShutdownGrace default = %v", cfg.ShutdownGrace)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("LogLevel default = %q", cfg.LogLevel)
+	}
+}
+
+func TestLoadConfig_FailClosedOnMissingCIDR(t *testing.T) {
+	if _, err := LoadConfig(mapEnv(map[string]string{})); err == nil {
+		t.Fatal("expected error when ALLOW_CIDR missing, got nil")
+	}
+}
+
+func TestLoadConfig_RejectsInvalidDuration(t *testing.T) {
+	_, err := LoadConfig(mapEnv(map[string]string{
+		"RCP_NS_PROXY_ALLOW_CIDR":   "192.168.0.0/16",
+		"RCP_NS_PROXY_DIAL_TIMEOUT": "five-seconds",
+	}))
+	if err == nil {
+		t.Fatal("expected error for invalid duration, got nil")
+	}
+}
+
+func TestLoadConfig_RejectsInvalidInt(t *testing.T) {
+	_, err := LoadConfig(mapEnv(map[string]string{
+		"RCP_NS_PROXY_ALLOW_CIDR": "192.168.0.0/16",
+		"RCP_NS_PROXY_MAX_CONNS":  "lots",
+	}))
+	if err == nil {
+		t.Fatal("expected error for invalid int, got nil")
+	}
+}
+
+func TestLoadConfig_OverridesAll(t *testing.T) {
+	cfg, err := LoadConfig(mapEnv(map[string]string{
+		"RCP_NS_PROXY_SOCK":           "/tmp/x.sock",
+		"RCP_NS_PROXY_ALLOW_CIDR":     "10.0.0.0/8",
+		"RCP_NS_PROXY_MAX_CONNS":      "256",
+		"RCP_NS_PROXY_DIAL_TIMEOUT":   "2s",
+		"RCP_NS_PROXY_SHUTDOWN_GRACE": "10s",
+		"RCP_NS_PROXY_LOG_LEVEL":      "debug",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SockPath != "/tmp/x.sock" || cfg.MaxConns != 256 ||
+		cfg.DialTimeout != 2*time.Second || cfg.ShutdownGrace != 10*time.Second ||
+		cfg.LogLevel != "debug" {
+		t.Errorf("override mismatch: %+v", cfg)
+	}
+	if cfg.AllowList == nil || !cfg.AllowList.Contains(net.ParseIP("10.0.0.5")) {
+		t.Error("AllowList override did not apply correctly")
+	}
+}
+
+func TestLoadConfig_RejectsInvalidCIDR(t *testing.T) {
+	_, err := LoadConfig(mapEnv(map[string]string{
+		"RCP_NS_PROXY_ALLOW_CIDR": "not-a-cidr",
+	}))
+	if err == nil {
+		t.Fatal("expected error for invalid CIDR, got nil")
+	}
+}
+
+func TestLoadConfig_RejectsZeroOrNegativeMaxConns(t *testing.T) {
+	for _, v := range []string{"0", "-1"} {
+		_, err := LoadConfig(mapEnv(map[string]string{
+			"RCP_NS_PROXY_ALLOW_CIDR": "192.168.0.0/16",
+			"RCP_NS_PROXY_MAX_CONNS":  v,
+		}))
+		if err == nil {
+			t.Errorf("MAX_CONNS=%q should error, got nil", v)
+		}
+	}
+}
+
+func TestLoadConfig_RejectsNonPositiveDurations(t *testing.T) {
+	for _, key := range []string{"RCP_NS_PROXY_DIAL_TIMEOUT", "RCP_NS_PROXY_SHUTDOWN_GRACE"} {
+		for _, v := range []string{"0s", "-1s"} {
+			_, err := LoadConfig(mapEnv(map[string]string{
+				"RCP_NS_PROXY_ALLOW_CIDR": "192.168.0.0/16",
+				key:                       v,
+			}))
+			if err == nil {
+				t.Errorf("%s=%q should error, got nil", key, v)
+			}
+		}
+	}
+}
+
+func TestLoadConfig_RejectsRelativeSockPath(t *testing.T) {
+	for _, v := range []string{"tmp/x.sock", "   ", "relative/path"} {
+		_, err := LoadConfig(mapEnv(map[string]string{
+			"RCP_NS_PROXY_ALLOW_CIDR": "192.168.0.0/16",
+			"RCP_NS_PROXY_SOCK":       v,
+		}))
+		if err == nil {
+			t.Errorf("SOCK=%q should error, got nil", v)
+		}
+	}
+}
+
+func TestLoadConfig_RejectsInvalidLogLevel(t *testing.T) {
+	for _, v := range []string{"warning", "INFOO", "trace"} {
+		_, err := LoadConfig(mapEnv(map[string]string{
+			"RCP_NS_PROXY_ALLOW_CIDR": "192.168.0.0/16",
+			"RCP_NS_PROXY_LOG_LEVEL":  v,
+		}))
+		if err == nil {
+			t.Errorf("LOG_LEVEL=%q should error, got nil", v)
+		}
+	}
+}
+
+func TestLoadConfig_LogLevelCaseInsensitive(t *testing.T) {
+	cfg, err := LoadConfig(mapEnv(map[string]string{
+		"RCP_NS_PROXY_ALLOW_CIDR": "192.168.0.0/16",
+		"RCP_NS_PROXY_LOG_LEVEL":  "DEBUG",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q, want debug", cfg.LogLevel)
+	}
+}

--- a/cmd/ns-proxy/main.go
+++ b/cmd/ns-proxy/main.go
@@ -27,7 +27,7 @@ func main() {
 	if err := os.MkdirAll(filepath.Dir(cfg.SockPath), 0o750); err != nil {
 		fatal("mkdir socket dir: %v", err)
 	}
-	_ = os.Remove(cfg.SockPath) // tolerate stale socket from prior crash; recreated below
+	_ = os.Remove(cfg.SockPath) // 이전 크래시로 남은 stale 소켓 허용 — 아래에서 재생성
 
 	ln, err := net.Listen("unix", cfg.SockPath)
 	if err != nil {
@@ -49,38 +49,32 @@ func main() {
 
 	ctx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 
-	// Stats logger: emit once at startup + every statsInterval until ctx cancels.
 	statsCtx, statsCancel := context.WithCancel(ctx)
 	defer statsCancel()
 	go statsLoop(statsCtx, srv, log, statsInterval)
 
-	// Serve in a goroutine so we can react to signals.
 	serveErr := make(chan error, 1)
 	go func() { serveErr <- srv.Serve(ctx, ln) }()
 
-	// Track whether Serve already returned during the first select so we don't
-	// wait for it a second time (the channel has already been drained).
+	// Serve가 첫 select에서 이미 끝났는지 — 끝났다면 채널이 비어 있어 두 번째 대기를 건너뜀.
 	var serveExited bool
 	select {
 	case <-ctx.Done():
-		// Signal received, fall through to shutdown.
 	case err := <-serveErr:
 		serveExited = true
 		if err != nil {
 			log.Error("serve aborted", "err", err)
 			os.Exit(1)
 		}
-		// Serve returned nil unexpectedly (listener closed externally?). Still graceful.
 	}
 
-	// Restore default signal behavior so a second SIGTERM/SIGINT kills immediately
-	// instead of being absorbed by the (already-cancelled) signal context.
+	// 신호 컨텍스트가 이미 cancel된 상태라 두 번째 SIGTERM/SIGINT는 흡수됨.
+	// 기본 핸들러를 복원해 두 번째 시그널이 즉시 프로세스를 죽이도록.
 	stopSignals()
 
 	active, _, _ := srv.Stats()
 	log.Info("shutting down", "active_conns", active)
 
-	// Stop accepting new conns; drain in-flight.
 	_ = ln.Close()
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownGrace)
@@ -91,9 +85,6 @@ func main() {
 		log.Info("drained gracefully")
 	}
 
-	// Wait for Serve goroutine to publish its final return — but only if it
-	// hadn't already exited during the first select above (otherwise serveErr
-	// is empty and we'd spuriously hit the timeout branch).
 	if !serveExited {
 		select {
 		case err := <-serveErr:
@@ -106,8 +97,6 @@ func main() {
 	}
 }
 
-// statsLoop logs counter snapshots once at startup and then on every interval
-// until ctx is cancelled.
 func statsLoop(ctx context.Context, srv *Server, log *slog.Logger, interval time.Duration) {
 	emit := func() {
 		active, total, denied := srv.Stats()

--- a/cmd/ns-proxy/main.go
+++ b/cmd/ns-proxy/main.go
@@ -58,10 +58,14 @@ func main() {
 	serveErr := make(chan error, 1)
 	go func() { serveErr <- srv.Serve(ctx, ln) }()
 
+	// Track whether Serve already returned during the first select so we don't
+	// wait for it a second time (the channel has already been drained).
+	var serveExited bool
 	select {
 	case <-ctx.Done():
 		// Signal received, fall through to shutdown.
 	case err := <-serveErr:
+		serveExited = true
 		if err != nil {
 			log.Error("serve aborted", "err", err)
 			os.Exit(1)
@@ -87,14 +91,18 @@ func main() {
 		log.Info("drained gracefully")
 	}
 
-	// Wait for Serve goroutine to publish its final return.
-	select {
-	case err := <-serveErr:
-		if err != nil && !errors.Is(err, net.ErrClosed) {
-			log.Warn("serve returned error", "err", err)
+	// Wait for Serve goroutine to publish its final return — but only if it
+	// hadn't already exited during the first select above (otherwise serveErr
+	// is empty and we'd spuriously hit the timeout branch).
+	if !serveExited {
+		select {
+		case err := <-serveErr:
+			if err != nil && !errors.Is(err, net.ErrClosed) {
+				log.Warn("serve returned error", "err", err)
+			}
+		case <-time.After(2 * time.Second):
+			log.Warn("serve goroutine did not return after shutdown")
 		}
-	case <-time.After(2 * time.Second):
-		log.Warn("serve goroutine did not return after shutdown")
 	}
 }
 

--- a/cmd/ns-proxy/main.go
+++ b/cmd/ns-proxy/main.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const statsInterval = time.Minute
+
+func main() {
+	cfg, err := LoadConfig(os.Getenv)
+	if err != nil {
+		fatal("config load failed: %v", err)
+	}
+
+	log := newLogger(cfg.LogLevel)
+
+	if err := os.MkdirAll(filepath.Dir(cfg.SockPath), 0o750); err != nil {
+		fatal("mkdir socket dir: %v", err)
+	}
+	_ = os.Remove(cfg.SockPath) // tolerate stale socket from prior crash; recreated below
+
+	ln, err := net.Listen("unix", cfg.SockPath)
+	if err != nil {
+		fatal("listen %s: %v", cfg.SockPath, err)
+	}
+	if err := os.Chmod(cfg.SockPath, 0o660); err != nil {
+		fatal("chmod %s: %v", cfg.SockPath, err)
+	}
+
+	srv := NewServer(cfg, log)
+
+	log.Info("ns-proxy started",
+		"sock", cfg.SockPath,
+		"max_conns", cfg.MaxConns,
+		"dial_timeout", cfg.DialTimeout,
+		"shutdown_grace", cfg.ShutdownGrace,
+		"log_level", cfg.LogLevel,
+	)
+
+	ctx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+
+	// Stats logger: emit once at startup + every statsInterval until ctx cancels.
+	statsCtx, statsCancel := context.WithCancel(ctx)
+	defer statsCancel()
+	go statsLoop(statsCtx, srv, log, statsInterval)
+
+	// Serve in a goroutine so we can react to signals.
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ctx, ln) }()
+
+	select {
+	case <-ctx.Done():
+		// Signal received, fall through to shutdown.
+	case err := <-serveErr:
+		if err != nil {
+			log.Error("serve aborted", "err", err)
+			os.Exit(1)
+		}
+		// Serve returned nil unexpectedly (listener closed externally?). Still graceful.
+	}
+
+	// Restore default signal behavior so a second SIGTERM/SIGINT kills immediately
+	// instead of being absorbed by the (already-cancelled) signal context.
+	stopSignals()
+
+	active, _, _ := srv.Stats()
+	log.Info("shutting down", "active_conns", active)
+
+	// Stop accepting new conns; drain in-flight.
+	_ = ln.Close()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownGrace)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Warn("grace timeout, forcing close", "err", err)
+	} else {
+		log.Info("drained gracefully")
+	}
+
+	// Wait for Serve goroutine to publish its final return.
+	select {
+	case err := <-serveErr:
+		if err != nil && !errors.Is(err, net.ErrClosed) {
+			log.Warn("serve returned error", "err", err)
+		}
+	case <-time.After(2 * time.Second):
+		log.Warn("serve goroutine did not return after shutdown")
+	}
+}
+
+// statsLoop logs counter snapshots once at startup and then on every interval
+// until ctx is cancelled.
+func statsLoop(ctx context.Context, srv *Server, log *slog.Logger, interval time.Duration) {
+	emit := func() {
+		active, total, denied := srv.Stats()
+		log.Info("stats", "active", active, "total_dials", total, "denied", denied)
+	}
+	emit()
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			emit()
+		}
+	}
+}
+
+func newLogger(level string) *slog.Logger {
+	var lvl slog.Level
+	switch strings.ToLower(level) {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "warn":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+	h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: lvl})
+	return slog.New(h)
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "ns-proxy fatal: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/ns-proxy/main.go
+++ b/cmd/ns-proxy/main.go
@@ -33,7 +33,8 @@ func main() {
 	if err != nil {
 		fatal("listen %s: %v", cfg.SockPath, err)
 	}
-	if err := os.Chmod(cfg.SockPath, 0o660); err != nil {
+	// 0o660: 같은 그룹의 클라이언트가 Unix 소켓에 connect할 수 있도록 group write 허용.
+	if err := os.Chmod(cfg.SockPath, 0o660); err != nil { //nolint:gosec // G302: socket needs group rw for peer access
 		fatal("chmod %s: %v", cfg.SockPath, err)
 	}
 

--- a/cmd/ns-proxy/main_test.go
+++ b/cmd/ns-proxy/main_test.go
@@ -9,9 +9,8 @@ import (
 	"time"
 )
 
-// mustAllowlist is a test helper that parses a CIDR spec and fatals on error.
-// Tests across this package (server_test.go, main_test.go) can call it freely
-// since all files share the same package main test binary.
+// mustAllowlist는 CIDR spec을 파싱하고 에러 시 t.Fatal하는 테스트 헬퍼.
+// package main 테스트 바이너리를 공유하므로 server_test.go/main_test.go에서 자유롭게 호출 가능.
 func mustAllowlist(t *testing.T, cidr string) *Allowlist {
 	t.Helper()
 	al, err := ParseCIDRs(cidr)
@@ -25,15 +24,15 @@ func TestNewLogger_LevelMapping(t *testing.T) {
 	cases := []struct {
 		in           string
 		wantEnabled  slog.Level
-		wantDisabled slog.Level // a level strictly below wantEnabled; zero value unused for "debug"
-		checkBelow   bool       // whether to assert wantDisabled is NOT enabled
+		wantDisabled slog.Level // wantEnabled보다 한 단계 아래; "debug"일 때는 사용 안 함
+		checkBelow   bool       // wantDisabled가 비활성인지 검사할지 여부
 	}{
-		{"debug", slog.LevelDebug, 0, false},             // nothing strictly below debug
-		{"info", slog.LevelInfo, slog.LevelDebug, true},  // debug must be off
-		{"warn", slog.LevelWarn, slog.LevelInfo, true},   // info must be off
-		{"error", slog.LevelError, slog.LevelWarn, true}, // warn must be off
-		{"", slog.LevelInfo, slog.LevelDebug, true},      // default → info; debug must be off
-		{"weird", slog.LevelInfo, slog.LevelDebug, true}, // unknown → info; debug must be off
+		{"debug", slog.LevelDebug, 0, false},             // debug 아래는 없음
+		{"info", slog.LevelInfo, slog.LevelDebug, true},  // debug는 꺼져 있어야
+		{"warn", slog.LevelWarn, slog.LevelInfo, true},   // info는 꺼져 있어야
+		{"error", slog.LevelError, slog.LevelWarn, true}, // warn은 꺼져 있어야
+		{"", slog.LevelInfo, slog.LevelDebug, true},      // default → info; debug는 꺼져 있어야
+		{"weird", slog.LevelInfo, slog.LevelDebug, true}, // unknown → info; debug는 꺼져 있어야
 	}
 	for _, c := range cases {
 		log := newLogger(c.in)
@@ -60,12 +59,12 @@ func TestStatsLoop_EmitsAtStartAndInterval(t *testing.T) {
 	done := make(chan struct{})
 	go func() { defer close(done); statsLoop(ctx, srv, log, 50*time.Millisecond) }()
 
-	// Wait long enough for at least 2 emissions (startup + 1 tick).
+	// 최소 2회(시작 + 1 tick) 출력될 만큼 대기.
 	time.Sleep(120 * time.Millisecond)
 	cancel()
 	<-done
 
-	// Count "stats" entries.
+	// "stats" 엔트리 개수 카운트.
 	n := strings.Count(buf.String(), `msg=stats`)
 	if n < 2 {
 		t.Errorf("got %d stats lines, want >=2", n)

--- a/cmd/ns-proxy/main_test.go
+++ b/cmd/ns-proxy/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mustAllowlist is a test helper that parses a CIDR spec and fatals on error.
+// Tests across this package (server_test.go, main_test.go) can call it freely
+// since all files share the same package main test binary.
+func mustAllowlist(t *testing.T, cidr string) *Allowlist {
+	t.Helper()
+	al, err := ParseCIDRs(cidr)
+	if err != nil {
+		t.Fatalf("mustAllowlist(%q): %v", cidr, err)
+	}
+	return al
+}
+
+func TestNewLogger_LevelMapping(t *testing.T) {
+	cases := []struct {
+		in           string
+		wantEnabled  slog.Level
+		wantDisabled slog.Level // a level strictly below wantEnabled; zero value unused for "debug"
+		checkBelow   bool       // whether to assert wantDisabled is NOT enabled
+	}{
+		{"debug", slog.LevelDebug, 0, false},             // nothing strictly below debug
+		{"info", slog.LevelInfo, slog.LevelDebug, true},  // debug must be off
+		{"warn", slog.LevelWarn, slog.LevelInfo, true},   // info must be off
+		{"error", slog.LevelError, slog.LevelWarn, true}, // warn must be off
+		{"", slog.LevelInfo, slog.LevelDebug, true},      // default → info; debug must be off
+		{"weird", slog.LevelInfo, slog.LevelDebug, true}, // unknown → info; debug must be off
+	}
+	for _, c := range cases {
+		log := newLogger(c.in)
+		if !log.Enabled(context.Background(), c.wantEnabled) {
+			t.Errorf("newLogger(%q): want %v enabled", c.in, c.wantEnabled)
+		}
+		if c.checkBelow && log.Enabled(context.Background(), c.wantDisabled) {
+			t.Errorf("newLogger(%q): %v should NOT be enabled", c.in, c.wantDisabled)
+		}
+	}
+}
+
+func TestStatsLoop_EmitsAtStartAndInterval(t *testing.T) {
+	cfg := &Config{
+		AllowList:   mustAllowlist(t, "127.0.0.0/8"),
+		MaxConns:    4,
+		DialTimeout: time.Second,
+	}
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	srv := NewServer(cfg, log)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); statsLoop(ctx, srv, log, 50*time.Millisecond) }()
+
+	// Wait long enough for at least 2 emissions (startup + 1 tick).
+	time.Sleep(120 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Count "stats" entries.
+	n := strings.Count(buf.String(), `msg=stats`)
+	if n < 2 {
+		t.Errorf("got %d stats lines, want >=2", n)
+	}
+}

--- a/cmd/ns-proxy/server.go
+++ b/cmd/ns-proxy/server.go
@@ -13,30 +13,24 @@ import (
 	socks5 "github.com/things-go/go-socks5"
 )
 
-// shutdownPollInterval is how often Shutdown checks activeConns while waiting
-// for in-flight handlers to drain.
 const shutdownPollInterval = 50 * time.Millisecond
 
-// Server wraps a *socks5.Server with a semaphore (to cap concurrent
-// connections) and a graceful-shutdown procedure. The caller owns the listener
-// lifecycle: close the listener to stop the accept loop, then call Shutdown to
-// drain in-flight connections.
+// Server는 *socks5.Server를 동시 접속 semaphore + graceful shutdown으로 감싼다.
+// listener는 호출자 소유: close → accept loop 종료, Shutdown으로 drain.
 type Server struct {
 	log         *slog.Logger
 	socksServer *socks5.Server
 	sem         chan struct{}
 	wg          sync.WaitGroup
 
-	serveDone chan struct{} // closed when Serve returns
+	serveDone chan struct{}
 	serveOnce sync.Once
 
-	activeConns int64 // updated with sync/atomic
-	totalDials  int64 // updated with sync/atomic
-	deniedDials int64 // updated with sync/atomic
+	activeConns int64 // sync/atomic으로만 접근
+	totalDials  int64
+	deniedDials int64
 }
 
-// NewServer constructs a Server. cfg.MaxConns is guaranteed > 0 by Config
-// validation, so sem always has positive capacity.
 func NewServer(cfg *Config, log *slog.Logger) *Server {
 	return &Server{
 		log:         log,
@@ -46,14 +40,8 @@ func NewServer(cfg *Config, log *slog.Logger) *Server {
 	}
 }
 
-// Serve runs the accept loop on ln. ctx is accepted for caller-side API
-// symmetry but is intentionally NOT consulted here; cancel the loop by closing
-// ln (caller's responsibility). This keeps the lib's ServeConn semantics
-// unchanged and avoids a second cancellation channel.
-//
-// Serve returns nil when the listener is closed (graceful shutdown path). Any
-// other accept failure triggers a logged backoff-retry so that transient OS
-// errors (EMFILE, EAGAIN) do not kill the daemon.
+// Serve는 ln의 accept loop를 돈다. ctx는 API 대칭으로 받지만 무시 — 종료는
+// 호출자가 ln을 close. transient accept 에러는 backoff-retry로 흡수.
 func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 	defer s.serveOnce.Do(func() { close(s.serveDone) })
 
@@ -62,14 +50,9 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 		conn, err := ln.Accept()
 		if err != nil {
 			if errors.Is(err, net.ErrClosed) {
-				// Listener was closed by the Shutdown caller. Drain active conns
-				// then signal a clean exit to the caller.
 				s.wg.Wait()
 				return nil
 			}
-			// Backoff and retry on transient errors. EMFILE, EAGAIN, etc.
-			// Permanent errors (e.g. listener gone for any reason other than ErrClosed)
-			// will show up as a continuous error stream that the operator sees in logs.
 			if tempDelay == 0 {
 				tempDelay = 10 * time.Millisecond
 			} else {
@@ -84,31 +67,20 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 		}
 		tempDelay = 0
 
-		// Non-blocking semaphore acquire.
 		select {
 		case s.sem <- struct{}{}:
 			atomic.AddInt64(&s.totalDials, 1)
 			atomic.AddInt64(&s.activeConns, 1)
 			s.wg.Add(1)
 			go func() {
-				// LIFO order will be: <-s.sem (first) → activeConns-- (middle) → wg.Done (last).
-				// wg.Done MUST be last so Shutdown's wg.Wait sees all in-flight goroutines
-				// even after activeConns reaches zero. The sem must release before activeConns--
-				// so capacity is available the instant Stats reports the slot is free.
-				defer s.wg.Done()                         // registered 1st → runs LAST
-				defer atomic.AddInt64(&s.activeConns, -1) // registered 2nd
-				defer func() { <-s.sem }()                // registered 3rd → runs FIRST
-				// TODO(P2): the lib has no handshake-only read deadline hook. A slow/silent
-				// client that completes TCP but never sends a SOCKS5 greeting can pin a sem
-				// slot indefinitely. Mitigation options under consideration:
-				//   - cfg.HandshakeTimeout + conn.SetReadDeadline before ServeConn (but lib
-				//     doesn't clear deadline post-handshake, breaking long-lived sessions)
-				//   - timeoutConn wrapper that clears the deadline after the first ~10 bytes
-				//   - patch lib to expose a handshake hook
-				// Defer to a separate issue; do not attempt here.
+				// defer LIFO: sem 해제 먼저 (슬롯 즉시 회수) → activeConns-- → wg.Done 마지막
+				// (Shutdown의 wg.Wait이 모든 goroutine 종료를 보게).
+				defer s.wg.Done()
+				defer atomic.AddInt64(&s.activeConns, -1)
+				defer func() { <-s.sem }()
+				// TODO(P2): lib에 handshake-only deadline 훅이 없어, slow-handshake
+				// 클라이언트가 슬롯을 무한 점유 가능. 별도 이슈로 분리.
 				if err := s.socksServer.ServeConn(conn); err != nil {
-					// EOF / ErrClosed are normal client-disconnect signals; log at
-					// debug to keep the info stream focused on real failures.
 					if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
 						s.log.Debug("serve conn closed", "err", err)
 					} else {
@@ -117,10 +89,7 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 				}
 			}()
 		default:
-			// Semaphore full — we cannot politely communicate a "try again" to
-			// a SOCKS5 client without completing the handshake first. Closing
-			// the TCP connection is the cleanest max-conns signal; the operator
-			// sees the denied counter increment in logs/metrics.
+			// 슬롯 만석 → SOCKS5 협상 전에 TCP를 끊는 것이 가장 명확한 신호.
 			atomic.AddInt64(&s.deniedDials, 1)
 			s.log.Warn("rejected: max conns reached")
 			_ = conn.Close()
@@ -128,18 +97,14 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 	}
 }
 
-// Shutdown waits for the accept loop to exit (caller MUST close the listener
-// first; calling Shutdown without closing the listener will block forever or
-// until ctx fires) and then for active handler goroutines to drain. Returns
-// nil on full drain, ctx.Err() if the context fires first.
+// Shutdown: (1) accept loop 종료 대기 → (2) in-flight 핸들러 drain.
+// 호출자는 먼저 listener를 close해야 함. drain 완료 시 nil, ctx 만료 시 ctx.Err().
 func (s *Server) Shutdown(ctx context.Context) error {
-	// 1. Wait for accept loop to fully exit (caller closed listener already).
 	select {
 	case <-s.serveDone:
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-	// 2. Drain in-flight handlers.
 	ticker := time.NewTicker(shutdownPollInterval)
 	defer ticker.Stop()
 	for {
@@ -155,9 +120,6 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 }
 
-// Stats returns a snapshot of the three connection counters. Values are
-// read atomically and may be slightly stale relative to each other, which is
-// acceptable for diagnostic/logging purposes.
 func (s *Server) Stats() (active, total, denied int64) {
 	return atomic.LoadInt64(&s.activeConns),
 		atomic.LoadInt64(&s.totalDials),

--- a/cmd/ns-proxy/server.go
+++ b/cmd/ns-proxy/server.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	socks5 "github.com/things-go/go-socks5"
+)
+
+// shutdownPollInterval is how often Shutdown checks activeConns while waiting
+// for in-flight handlers to drain.
+const shutdownPollInterval = 50 * time.Millisecond
+
+// Server wraps a *socks5.Server with a semaphore (to cap concurrent
+// connections) and a graceful-shutdown procedure. The caller owns the listener
+// lifecycle: close the listener to stop the accept loop, then call Shutdown to
+// drain in-flight connections.
+type Server struct {
+	cfg         *Config
+	log         *slog.Logger
+	socksServer *socks5.Server
+	sem         chan struct{}
+	wg          sync.WaitGroup
+
+	serveDone chan struct{} // closed when Serve returns
+	serveOnce sync.Once
+
+	activeConns int64 // updated with sync/atomic
+	totalDials  int64 // updated with sync/atomic
+	deniedDials int64 // updated with sync/atomic
+}
+
+// NewServer constructs a Server. cfg.MaxConns is guaranteed > 0 by Config
+// validation, so sem always has positive capacity.
+func NewServer(cfg *Config, log *slog.Logger) *Server {
+	return &Server{
+		cfg:         cfg,
+		log:         log,
+		socksServer: NewSOCKS5Server(cfg, log),
+		sem:         make(chan struct{}, cfg.MaxConns),
+		serveDone:   make(chan struct{}),
+	}
+}
+
+// Serve runs the accept loop on ln. ctx is accepted for caller-side API
+// symmetry but is intentionally NOT consulted here; cancel the loop by closing
+// ln (caller's responsibility). This keeps the lib's ServeConn semantics
+// unchanged and avoids a second cancellation channel.
+//
+// Serve returns nil when the listener is closed (graceful shutdown path). Any
+// other accept failure triggers a logged backoff-retry so that transient OS
+// errors (EMFILE, EAGAIN) do not kill the daemon.
+func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
+	defer s.serveOnce.Do(func() { close(s.serveDone) })
+
+	var tempDelay time.Duration
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				// Listener was closed by the Shutdown caller. Drain active conns
+				// then signal a clean exit to the caller.
+				s.wg.Wait()
+				return nil
+			}
+			// Backoff and retry on transient errors. EMFILE, EAGAIN, etc.
+			// Permanent errors (e.g. listener gone for any reason other than ErrClosed)
+			// will show up as a continuous error stream that the operator sees in logs.
+			if tempDelay == 0 {
+				tempDelay = 10 * time.Millisecond
+			} else {
+				tempDelay *= 2
+			}
+			if tempDelay > time.Second {
+				tempDelay = time.Second
+			}
+			s.log.Warn("accept transient error, retrying", "err", err, "delay", tempDelay)
+			time.Sleep(tempDelay)
+			continue
+		}
+		tempDelay = 0
+
+		// Non-blocking semaphore acquire.
+		select {
+		case s.sem <- struct{}{}:
+			atomic.AddInt64(&s.totalDials, 1)
+			atomic.AddInt64(&s.activeConns, 1)
+			s.wg.Add(1)
+			go func() {
+				// LIFO order will be: <-s.sem (first) → activeConns-- (middle) → wg.Done (last).
+				// wg.Done MUST be last so Shutdown's wg.Wait sees all in-flight goroutines
+				// even after activeConns reaches zero. The sem must release before activeConns--
+				// so capacity is available the instant Stats reports the slot is free.
+				defer s.wg.Done()                         // registered 1st → runs LAST
+				defer atomic.AddInt64(&s.activeConns, -1) // registered 2nd
+				defer func() { <-s.sem }()                // registered 3rd → runs FIRST
+				// TODO(P2): the lib has no handshake-only read deadline hook. A slow/silent
+				// client that completes TCP but never sends a SOCKS5 greeting can pin a sem
+				// slot indefinitely. Mitigation options under consideration:
+				//   - cfg.HandshakeTimeout + conn.SetReadDeadline before ServeConn (but lib
+				//     doesn't clear deadline post-handshake, breaking long-lived sessions)
+				//   - timeoutConn wrapper that clears the deadline after the first ~10 bytes
+				//   - patch lib to expose a handshake hook
+				// Defer to a separate issue; do not attempt here.
+				if err := s.socksServer.ServeConn(conn); err != nil {
+					s.log.Info("serve conn closed", "err", err)
+				}
+			}()
+		default:
+			// Semaphore full — we cannot politely communicate a "try again" to
+			// a SOCKS5 client without completing the handshake first. Closing
+			// the TCP connection is the cleanest max-conns signal; the operator
+			// sees the denied counter increment in logs/metrics.
+			atomic.AddInt64(&s.deniedDials, 1)
+			s.log.Warn("rejected: max conns reached")
+			_ = conn.Close()
+		}
+	}
+}
+
+// Shutdown waits for the accept loop to exit (caller MUST close the listener
+// first; calling Shutdown without closing the listener will block forever or
+// until ctx fires) and then for active handler goroutines to drain. Returns
+// nil on full drain, ctx.Err() if the context fires first.
+func (s *Server) Shutdown(ctx context.Context) error {
+	// 1. Wait for accept loop to fully exit (caller closed listener already).
+	select {
+	case <-s.serveDone:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	// 2. Drain in-flight handlers.
+	ticker := time.NewTicker(shutdownPollInterval)
+	defer ticker.Stop()
+	for {
+		if atomic.LoadInt64(&s.activeConns) == 0 {
+			s.wg.Wait()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// Stats returns a snapshot of the three connection counters. Values are
+// read atomically and may be slightly stale relative to each other, which is
+// acceptable for diagnostic/logging purposes.
+func (s *Server) Stats() (active, total, denied int64) {
+	return atomic.LoadInt64(&s.activeConns),
+		atomic.LoadInt64(&s.totalDials),
+		atomic.LoadInt64(&s.deniedDials)
+}

--- a/cmd/ns-proxy/server.go
+++ b/cmd/ns-proxy/server.go
@@ -22,7 +22,6 @@ const shutdownPollInterval = 50 * time.Millisecond
 // lifecycle: close the listener to stop the accept loop, then call Shutdown to
 // drain in-flight connections.
 type Server struct {
-	cfg         *Config
 	log         *slog.Logger
 	socksServer *socks5.Server
 	sem         chan struct{}
@@ -40,7 +39,6 @@ type Server struct {
 // validation, so sem always has positive capacity.
 func NewServer(cfg *Config, log *slog.Logger) *Server {
 	return &Server{
-		cfg:         cfg,
 		log:         log,
 		socksServer: NewSOCKS5Server(cfg, log),
 		sem:         make(chan struct{}, cfg.MaxConns),

--- a/cmd/ns-proxy/server.go
+++ b/cmd/ns-proxy/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"net"
 	"sync"
@@ -108,7 +109,13 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 				//   - patch lib to expose a handshake hook
 				// Defer to a separate issue; do not attempt here.
 				if err := s.socksServer.ServeConn(conn); err != nil {
-					s.log.Info("serve conn closed", "err", err)
+					// EOF / ErrClosed are normal client-disconnect signals; log at
+					// debug to keep the info stream focused on real failures.
+					if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+						s.log.Debug("serve conn closed", "err", err)
+					} else {
+						s.log.Info("serve conn closed", "err", err)
+					}
 				}
 			}()
 		default:

--- a/cmd/ns-proxy/server_test.go
+++ b/cmd/ns-proxy/server_test.go
@@ -17,8 +17,7 @@ import (
 
 // ---------- helpers ----------
 
-// startEcho starts a TCP echo server on 127.0.0.1:0. The returned addr is the
-// address clients should connect to; stop must be called to shut it down.
+// startEcho는 127.0.0.1:0에 TCP echo 서버를 띄운다.
 func startEcho(t *testing.T) (addr string, stop func()) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -40,30 +39,22 @@ func startEcho(t *testing.T) (addr string, stop func()) {
 	return ln.Addr().String(), func() { ln.Close() }
 }
 
-// testServerHandles groups the handles returned by newTestServerFull.
 type testServerHandles struct {
 	srv      *Server
 	sockPath string
-	// closeLn closes the Unix listener immediately (non-blocking).
-	// After closeLn, Serve's accept loop will see net.ErrClosed and call
-	// s.wg.Wait() before returning via serveDone.
+	// closeLn은 listener를 즉시 닫는다 (non-blocking). 닫으면 Serve의 accept
+	// loop가 net.ErrClosed → wg.Wait → serveDone 순으로 정리.
 	closeLn func()
-	// waitServe blocks until Serve returns (use after closeLn + all conns
-	// closed). Registering as t.Cleanup ensures goroutine-leak-free tests.
+	// waitServe는 Serve goroutine이 실제로 종료될 때까지 블록.
 	waitServe func()
-	// serveErr receives the error returned by Serve exactly once (buffered,
-	// capacity 1). The channel is closed after the error is placed so it is
-	// safe to read via a select with a timeout.
+	// serveErr는 Serve의 리턴값 1회 수신 (capacity 1 buffered).
 	serveErr <-chan error
 }
 
-// newTestServerFull creates a Server + Unix-socket listener, starts Serve in a
-// goroutine, and returns handles for fine-grained control. The caller is
-// responsible for eventually calling closeLn (to stop accepting) and
-// waitServe (to confirm the goroutine exited).
+// newTestServerFull은 Server + Unix 소켓 listener를 만들고 Serve를 goroutine으로
+// 띄운다. 호출자는 closeLn(수신 중단) + waitServe(goroutine 종료 확인) 책임.
 //
-// macOS limits Unix socket paths to 104 chars, so we create a short temp dir
-// under /tmp rather than using t.TempDir() (whose paths exceed that limit).
+// macOS는 Unix 소켓 경로 길이를 104자로 제한하므로 t.TempDir() 대신 짧은 /tmp 하위 디렉터리를 사용.
 func newTestServerFull(t *testing.T, cidr string, maxConns int, dialTimeout time.Duration) testServerHandles {
 	t.Helper()
 	al, err := ParseCIDRs(cidr)
@@ -90,8 +81,8 @@ func newTestServerFull(t *testing.T, cidr string, maxConns int, dialTimeout time
 		t.Fatalf("listen unix %s: %v", sockPath, err)
 	}
 
-	// errCh receives Serve's return value. The intermediary goroutine reads it,
-	// puts it back (so tests can inspect it), and closes serveDone.
+	// 중간 goroutine이 Serve의 리턴값을 받아 errCh에 다시 넣고 serveDone을 닫음
+	// → 테스트가 errCh를 select로 검사 가능.
 	rawErrCh := make(chan error, 1)
 	go func() { rawErrCh <- srv.Serve(context.Background(), ln) }()
 
@@ -106,13 +97,10 @@ func newTestServerFull(t *testing.T, cidr string, maxConns int, dialTimeout time
 	closeLn := sync.OnceFunc(func() { ln.Close() })
 	waitServe := func() { <-serveDone }
 
-	// Guarantee cleanup even if the test forgets.
 	t.Cleanup(func() {
 		closeLn()
-		// Don't call waitServe here because Serve blocks in wg.Wait until all
-		// active goroutines finish — tests that hold connections open past
-		// t.Cleanup would deadlock. Leaking the goroutine at test-process exit
-		// is acceptable.
+		// 여기서 waitServe를 부르지 않음 — 테스트가 conn을 닫지 않은 채 t.Cleanup에
+		// 진입하면 Serve의 wg.Wait이 무한 대기 → deadlock. 프로세스 종료 시 leak 허용.
 	})
 
 	return testServerHandles{
@@ -124,13 +112,11 @@ func newTestServerFull(t *testing.T, cidr string, maxConns int, dialTimeout time
 	}
 }
 
-// socks5Dialer returns a proxy.Dialer that tunnels through the Unix-socket
-// SOCKS5 server at sockPath.
+// socks5Dialer는 Unix 소켓 SOCKS5 서버를 거쳐 dial하는 proxy.Dialer를 반환.
 func socks5Dialer(t *testing.T, sockPath string) proxy.Dialer {
 	t.Helper()
-	// golang.org/x/net/proxy.SOCKS5 needs a network+address for the proxy, but
-	// we intercept the underlying Dial via a custom forwarder that actually
-	// connects to the Unix socket — the "address" field is ignored.
+	// proxy.SOCKS5는 network+address를 요구하지만 forward dialer로 Unix 소켓을
+	// 직접 잡으므로 "address"는 무시됨.
 	forward := &unixDialer{path: sockPath}
 	d, err := proxy.SOCKS5("tcp", "unused", nil, forward)
 	if err != nil {
@@ -139,16 +125,14 @@ func socks5Dialer(t *testing.T, sockPath string) proxy.Dialer {
 	return d
 }
 
-// unixDialer is a proxy.Dialer that ignores its address argument and always
-// connects to the named Unix socket. This lets golang.org/x/net/proxy reach
-// our Unix-socket SOCKS5 server.
+// unixDialer는 address 인자를 무시하고 항상 지정된 Unix 소켓에 연결.
 type unixDialer struct{ path string }
 
 func (u *unixDialer) Dial(_, _ string) (net.Conn, error) {
 	return net.Dial("unix", u.path)
 }
 
-// waitActiveConns polls srv.Stats until active >= n or 2 s elapses.
+// waitActiveConns는 srv.Stats의 active가 n 이상이 될 때까지 폴링 (max 2초).
 func waitActiveConns(t *testing.T, srv *Server, n int64) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -165,8 +149,7 @@ func waitActiveConns(t *testing.T, srv *Server, n int64) {
 
 // ---------- tests ----------
 
-// TestServer_DialsAllowedDestination verifies that a SOCKS5 client can reach
-// an echo server whose IP falls in the allowlist, and that data flows through.
+// SOCKS5 클라이언트가 allowlist 안의 echo 서버에 닿고 데이터가 양방향으로 흐르는지 검증.
 func TestServer_DialsAllowedDestination(t *testing.T) {
 	echoAddr, stopEcho := startEcho(t)
 	defer stopEcho()
@@ -193,9 +176,7 @@ func TestServer_DialsAllowedDestination(t *testing.T) {
 	}
 }
 
-// TestServer_RejectsDeniedDestination verifies that a dial to an IP outside
-// the allowlist fails at the SOCKS5 level (lib sends a non-success reply;
-// golang.org/x/net/proxy surfaces it as an error).
+// allowlist 밖 IP는 SOCKS5 레벨에서 거부 (lib이 non-success reply, proxy는 에러로 surface).
 func TestServer_RejectsDeniedDestination(t *testing.T) {
 	h := newTestServerFull(t, "127.0.0.0/8", 10, 2*time.Second)
 	defer h.closeLn()
@@ -207,9 +188,7 @@ func TestServer_RejectsDeniedDestination(t *testing.T) {
 	}
 }
 
-// TestServer_RejectsAtMaxConns verifies that when the semaphore is full the
-// server closes new connections without doing SOCKS5 negotiation, and the
-// deniedDials counter increments.
+// sem이 가득 차면 서버는 SOCKS5 협상 없이 raw TCP를 끊고 deniedDials를 증가.
 func TestServer_RejectsAtMaxConns(t *testing.T) {
 	echoAddr, stopEcho := startEcho(t)
 	defer stopEcho()
@@ -219,18 +198,16 @@ func TestServer_RejectsAtMaxConns(t *testing.T) {
 
 	d := socks5Dialer(t, h.sockPath)
 
-	// Open the first connection and hold it open so the slot stays occupied.
+	// 첫 연결을 점유 상태로 유지.
 	conn1, err := d.Dial("tcp", echoAddr)
 	if err != nil {
 		t.Fatalf("first dial: %v", err)
 	}
 	defer conn1.Close()
 
-	// Wait for the first conn to be accounted for.
 	waitActiveConns(t, h.srv, 1)
 
-	// Second dial must fail: server closes the raw TCP conn before SOCKS5, so
-	// golang.org/x/net/proxy gets EOF or a reset during the handshake.
+	// 두 번째 dial은 실패 — 서버가 SOCKS5 전에 raw TCP를 끊어 proxy가 EOF/reset을 받음.
 	conn2, err := d.Dial("tcp", echoAddr)
 	if err == nil {
 		conn2.Close()
@@ -243,8 +220,7 @@ func TestServer_RejectsAtMaxConns(t *testing.T) {
 	}
 }
 
-// TestServer_StatsCountersIncrement verifies that a successful dial increments
-// totalDials, and that activeConns returns to zero after the connection closes.
+// 성공한 dial은 totalDials를 증가, 연결 종료 후 activeConns는 0으로 복귀.
 func TestServer_StatsCountersIncrement(t *testing.T) {
 	echoAddr, stopEcho := startEcho(t)
 	defer stopEcho()
@@ -266,7 +242,7 @@ func TestServer_StatsCountersIncrement(t *testing.T) {
 
 	conn.Close()
 
-	// After closing, activeConns should drop back to zero.
+	// 종료 후 activeConns가 0으로 떨어지는지 폴링.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		active, _, _ := h.srv.Stats()
@@ -279,12 +255,11 @@ func TestServer_StatsCountersIncrement(t *testing.T) {
 	t.Errorf("activeConns = %d after connection close; want 0", active)
 }
 
-// TestServer_ShutdownReturnsWhenIdle verifies that Shutdown returns immediately
-// (nil) when no connections are active.
+// active 연결이 없을 때 Shutdown은 즉시 nil 반환.
 func TestServer_ShutdownReturnsWhenIdle(t *testing.T) {
 	h := newTestServerFull(t, "127.0.0.0/8", 10, 2*time.Second)
 
-	// Close listener first so Serve can exit and serveDone fires.
+	// listener를 먼저 닫아야 Serve가 종료되고 serveDone이 fire됨.
 	h.closeLn()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -294,8 +269,7 @@ func TestServer_ShutdownReturnsWhenIdle(t *testing.T) {
 		t.Fatalf("Shutdown: %v", err)
 	}
 
-	// Shutdown waited on s.serveDone, so the accept loop has already exited
-	// and serveErr is available without blocking.
+	// Shutdown이 serveDone을 기다렸으므로 accept loop는 이미 종료, serveErr는 즉시 가용.
 	h.waitServe()
 	select {
 	case err := <-h.serveErr:
@@ -307,8 +281,7 @@ func TestServer_ShutdownReturnsWhenIdle(t *testing.T) {
 	}
 }
 
-// TestServer_ShutdownDrainsActiveConns verifies that Shutdown waits for an
-// in-flight connection and returns nil once it closes.
+// in-flight 연결이 있으면 Shutdown은 그것이 닫힐 때까지 대기 후 nil 반환.
 func TestServer_ShutdownDrainsActiveConns(t *testing.T) {
 	echoAddr, stopEcho := startEcho(t)
 	defer stopEcho()
@@ -323,13 +296,11 @@ func TestServer_ShutdownDrainsActiveConns(t *testing.T) {
 
 	waitActiveConns(t, h.srv, 1)
 
-	// Close the listener — stops accepting new connections.
-	// Serve will call s.wg.Wait() and block until all active goroutines finish.
-	// We do NOT call h.waitServe here because Serve is blocked until conn is
-	// closed, which happens below.
+	// listener를 닫으면 Serve는 wg.Wait로 진입해 active goroutine을 기다림.
+	// conn이 아래에서 닫히기 전까지 Serve가 블록되므로 여기서는 waitServe를 호출하지 않음.
 	h.closeLn()
 
-	// Release the connection after 100 ms so Shutdown can drain it.
+	// 100ms 후 conn 해제 → Shutdown이 drain 가능하도록.
 	go func() {
 		time.Sleep(100 * time.Millisecond)
 		conn.Close()
@@ -342,8 +313,6 @@ func TestServer_ShutdownDrainsActiveConns(t *testing.T) {
 		t.Fatalf("Shutdown returned error: %v", err)
 	}
 
-	// Shutdown waited on s.serveDone, so the accept loop has already exited
-	// and serveErr is available without blocking.
 	h.waitServe()
 	select {
 	case err := <-h.serveErr:
@@ -355,9 +324,7 @@ func TestServer_ShutdownDrainsActiveConns(t *testing.T) {
 	}
 }
 
-// TestServer_ShutdownGraceTimeout verifies that Shutdown returns
-// context.DeadlineExceeded when the context expires before all connections
-// drain.
+// drain 완료 전 ctx가 만료되면 Shutdown은 context.DeadlineExceeded 반환.
 func TestServer_ShutdownGraceTimeout(t *testing.T) {
 	echoAddr, stopEcho := startEcho(t)
 	defer stopEcho()
@@ -369,8 +336,7 @@ func TestServer_ShutdownGraceTimeout(t *testing.T) {
 		h.closeLn()
 		t.Fatalf("dial: %v", err)
 	}
-	// Deliberately hold the connection open past Shutdown's timeout; close it
-	// at the end so Serve's wg.Wait eventually unblocks.
+	// Shutdown 타임아웃 이후까지 conn을 의도적으로 유지; 끝에서 닫아 Serve의 wg.Wait이 풀리게.
 	defer conn.Close()
 
 	waitActiveConns(t, h.srv, 1)

--- a/cmd/ns-proxy/server_test.go
+++ b/cmd/ns-proxy/server_test.go
@@ -1,0 +1,387 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+// ---------- helpers ----------
+
+// startEcho starts a TCP echo server on 127.0.0.1:0. The returned addr is the
+// address clients should connect to; stop must be called to shut it down.
+func startEcho(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("startEcho listen: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				io.Copy(c, c) //nolint:errcheck
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { ln.Close() }
+}
+
+// testServerHandles groups the handles returned by newTestServerFull.
+type testServerHandles struct {
+	srv      *Server
+	sockPath string
+	// closeLn closes the Unix listener immediately (non-blocking).
+	// After closeLn, Serve's accept loop will see net.ErrClosed and call
+	// s.wg.Wait() before returning via serveDone.
+	closeLn func()
+	// waitServe blocks until Serve returns (use after closeLn + all conns
+	// closed). Registering as t.Cleanup ensures goroutine-leak-free tests.
+	waitServe func()
+	// serveErr receives the error returned by Serve exactly once (buffered,
+	// capacity 1). The channel is closed after the error is placed so it is
+	// safe to read via a select with a timeout.
+	serveErr <-chan error
+}
+
+// newTestServerFull creates a Server + Unix-socket listener, starts Serve in a
+// goroutine, and returns handles for fine-grained control. The caller is
+// responsible for eventually calling closeLn (to stop accepting) and
+// waitServe (to confirm the goroutine exited).
+//
+// macOS limits Unix socket paths to 104 chars, so we create a short temp dir
+// under /tmp rather than using t.TempDir() (whose paths exceed that limit).
+func newTestServerFull(t *testing.T, cidr string, maxConns int, dialTimeout time.Duration) testServerHandles {
+	t.Helper()
+	al, err := ParseCIDRs(cidr)
+	if err != nil {
+		t.Fatalf("ParseCIDRs: %v", err)
+	}
+	cfg := &Config{
+		AllowList:     al,
+		MaxConns:      maxConns,
+		DialTimeout:   dialTimeout,
+		ShutdownGrace: 5 * time.Second,
+	}
+	srv := NewServer(cfg, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	dir, err := os.MkdirTemp("/tmp", "ns-proxy-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	sockPath := fmt.Sprintf("%s/p.sock", dir)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix %s: %v", sockPath, err)
+	}
+
+	// errCh receives Serve's return value. The intermediary goroutine reads it,
+	// puts it back (so tests can inspect it), and closes serveDone.
+	rawErrCh := make(chan error, 1)
+	go func() { rawErrCh <- srv.Serve(context.Background(), ln) }()
+
+	errCh := make(chan error, 1)
+	serveDone := make(chan struct{})
+	go func() {
+		serveResult := <-rawErrCh
+		errCh <- serveResult
+		close(serveDone)
+	}()
+
+	closeLn := sync.OnceFunc(func() { ln.Close() })
+	waitServe := func() { <-serveDone }
+
+	// Guarantee cleanup even if the test forgets.
+	t.Cleanup(func() {
+		closeLn()
+		// Don't call waitServe here because Serve blocks in wg.Wait until all
+		// active goroutines finish — tests that hold connections open past
+		// t.Cleanup would deadlock. Leaking the goroutine at test-process exit
+		// is acceptable.
+	})
+
+	return testServerHandles{
+		srv:       srv,
+		sockPath:  sockPath,
+		closeLn:   closeLn,
+		waitServe: waitServe,
+		serveErr:  errCh,
+	}
+}
+
+// socks5Dialer returns a proxy.Dialer that tunnels through the Unix-socket
+// SOCKS5 server at sockPath.
+func socks5Dialer(t *testing.T, sockPath string) proxy.Dialer {
+	t.Helper()
+	// golang.org/x/net/proxy.SOCKS5 needs a network+address for the proxy, but
+	// we intercept the underlying Dial via a custom forwarder that actually
+	// connects to the Unix socket — the "address" field is ignored.
+	forward := &unixDialer{path: sockPath}
+	d, err := proxy.SOCKS5("tcp", "unused", nil, forward)
+	if err != nil {
+		t.Fatalf("proxy.SOCKS5: %v", err)
+	}
+	return d
+}
+
+// unixDialer is a proxy.Dialer that ignores its address argument and always
+// connects to the named Unix socket. This lets golang.org/x/net/proxy reach
+// our Unix-socket SOCKS5 server.
+type unixDialer struct{ path string }
+
+func (u *unixDialer) Dial(_, _ string) (net.Conn, error) {
+	return net.Dial("unix", u.path)
+}
+
+// waitActiveConns polls srv.Stats until active >= n or 2 s elapses.
+func waitActiveConns(t *testing.T, srv *Server, n int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		active, _, _ := srv.Stats()
+		if active >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	active, _, _ := srv.Stats()
+	t.Fatalf("activeConns = %d after 2s; want >= %d", active, n)
+}
+
+// ---------- tests ----------
+
+// TestServer_DialsAllowedDestination verifies that a SOCKS5 client can reach
+// an echo server whose IP falls in the allowlist, and that data flows through.
+func TestServer_DialsAllowedDestination(t *testing.T) {
+	echoAddr, stopEcho := startEcho(t)
+	defer stopEcho()
+
+	h := newTestServerFull(t, "127.0.0.0/8", 10, 2*time.Second)
+	defer h.closeLn()
+
+	conn, err := socks5Dialer(t, h.sockPath).Dial("tcp", echoAddr)
+	if err != nil {
+		t.Fatalf("dial via SOCKS5: %v", err)
+	}
+	defer conn.Close()
+
+	payload := []byte("ping-from-socks5")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != string(payload) {
+		t.Errorf("echo mismatch: got %q, want %q", buf, payload)
+	}
+}
+
+// TestServer_RejectsDeniedDestination verifies that a dial to an IP outside
+// the allowlist fails at the SOCKS5 level (lib sends a non-success reply;
+// golang.org/x/net/proxy surfaces it as an error).
+func TestServer_RejectsDeniedDestination(t *testing.T) {
+	h := newTestServerFull(t, "127.0.0.0/8", 10, 2*time.Second)
+	defer h.closeLn()
+
+	conn, err := socks5Dialer(t, h.sockPath).Dial("tcp", "8.8.8.8:53")
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected error dialing denied destination, got nil")
+	}
+}
+
+// TestServer_RejectsAtMaxConns verifies that when the semaphore is full the
+// server closes new connections without doing SOCKS5 negotiation, and the
+// deniedDials counter increments.
+func TestServer_RejectsAtMaxConns(t *testing.T) {
+	echoAddr, stopEcho := startEcho(t)
+	defer stopEcho()
+
+	h := newTestServerFull(t, "127.0.0.0/8", 1, 2*time.Second)
+	defer h.closeLn()
+
+	d := socks5Dialer(t, h.sockPath)
+
+	// Open the first connection and hold it open so the slot stays occupied.
+	conn1, err := d.Dial("tcp", echoAddr)
+	if err != nil {
+		t.Fatalf("first dial: %v", err)
+	}
+	defer conn1.Close()
+
+	// Wait for the first conn to be accounted for.
+	waitActiveConns(t, h.srv, 1)
+
+	// Second dial must fail: server closes the raw TCP conn before SOCKS5, so
+	// golang.org/x/net/proxy gets EOF or a reset during the handshake.
+	conn2, err := d.Dial("tcp", echoAddr)
+	if err == nil {
+		conn2.Close()
+		t.Fatal("expected error dialing at max conns, got nil")
+	}
+
+	_, _, denied := h.srv.Stats()
+	if denied < 1 {
+		t.Errorf("deniedDials = %d; want >= 1", denied)
+	}
+}
+
+// TestServer_StatsCountersIncrement verifies that a successful dial increments
+// totalDials, and that activeConns returns to zero after the connection closes.
+func TestServer_StatsCountersIncrement(t *testing.T) {
+	echoAddr, stopEcho := startEcho(t)
+	defer stopEcho()
+
+	h := newTestServerFull(t, "127.0.0.0/8", 10, 2*time.Second)
+	defer h.closeLn()
+
+	conn, err := socks5Dialer(t, h.sockPath).Dial("tcp", echoAddr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	waitActiveConns(t, h.srv, 1)
+
+	_, total, _ := h.srv.Stats()
+	if total < 1 {
+		t.Errorf("totalDials = %d; want >= 1", total)
+	}
+
+	conn.Close()
+
+	// After closing, activeConns should drop back to zero.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		active, _, _ := h.srv.Stats()
+		if active == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	active, _, _ := h.srv.Stats()
+	t.Errorf("activeConns = %d after connection close; want 0", active)
+}
+
+// TestServer_ShutdownReturnsWhenIdle verifies that Shutdown returns immediately
+// (nil) when no connections are active.
+func TestServer_ShutdownReturnsWhenIdle(t *testing.T) {
+	h := newTestServerFull(t, "127.0.0.0/8", 10, 2*time.Second)
+
+	// Close listener first so Serve can exit and serveDone fires.
+	h.closeLn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	if err := h.srv.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	// Shutdown waited on s.serveDone, so the accept loop has already exited
+	// and serveErr is available without blocking.
+	h.waitServe()
+	select {
+	case err := <-h.serveErr:
+		if err != nil {
+			t.Errorf("Serve returned error: %v", err)
+		}
+	default:
+		t.Error("serveErr channel empty after waitServe — Serve goroutine did not exit")
+	}
+}
+
+// TestServer_ShutdownDrainsActiveConns verifies that Shutdown waits for an
+// in-flight connection and returns nil once it closes.
+func TestServer_ShutdownDrainsActiveConns(t *testing.T) {
+	echoAddr, stopEcho := startEcho(t)
+	defer stopEcho()
+
+	h := newTestServerFull(t, "127.0.0.0/8", 10, 2*time.Second)
+
+	conn, err := socks5Dialer(t, h.sockPath).Dial("tcp", echoAddr)
+	if err != nil {
+		h.closeLn()
+		t.Fatalf("dial: %v", err)
+	}
+
+	waitActiveConns(t, h.srv, 1)
+
+	// Close the listener — stops accepting new connections.
+	// Serve will call s.wg.Wait() and block until all active goroutines finish.
+	// We do NOT call h.waitServe here because Serve is blocked until conn is
+	// closed, which happens below.
+	h.closeLn()
+
+	// Release the connection after 100 ms so Shutdown can drain it.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		conn.Close()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	if err := h.srv.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+
+	// Shutdown waited on s.serveDone, so the accept loop has already exited
+	// and serveErr is available without blocking.
+	h.waitServe()
+	select {
+	case err := <-h.serveErr:
+		if err != nil {
+			t.Errorf("Serve returned error: %v", err)
+		}
+	default:
+		t.Error("serveErr channel empty after waitServe — Serve goroutine did not exit")
+	}
+}
+
+// TestServer_ShutdownGraceTimeout verifies that Shutdown returns
+// context.DeadlineExceeded when the context expires before all connections
+// drain.
+func TestServer_ShutdownGraceTimeout(t *testing.T) {
+	echoAddr, stopEcho := startEcho(t)
+	defer stopEcho()
+
+	h := newTestServerFull(t, "127.0.0.0/8", 10, 2*time.Second)
+
+	conn, err := socks5Dialer(t, h.sockPath).Dial("tcp", echoAddr)
+	if err != nil {
+		h.closeLn()
+		t.Fatalf("dial: %v", err)
+	}
+	// Deliberately hold the connection open past Shutdown's timeout; close it
+	// at the end so Serve's wg.Wait eventually unblocks.
+	defer conn.Close()
+
+	waitActiveConns(t, h.srv, 1)
+
+	h.closeLn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err = h.srv.Shutdown(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Shutdown returned %v; want context.DeadlineExceeded", err)
+	}
+}

--- a/cmd/ns-proxy/server_test.go
+++ b/cmd/ns-proxy/server_test.go
@@ -31,12 +31,12 @@ func startEcho(t *testing.T) (addr string, stop func()) {
 				return // listener closed
 			}
 			go func(c net.Conn) {
-				defer c.Close()
-				io.Copy(c, c) //nolint:errcheck
+				defer func() { _ = c.Close() }()
+				_, _ = io.Copy(c, c)
 			}(conn)
 		}
 	}()
-	return ln.Addr().String(), func() { ln.Close() }
+	return ln.Addr().String(), func() { _ = ln.Close() }
 }
 
 type testServerHandles struct {
@@ -73,7 +73,7 @@ func newTestServerFull(t *testing.T, cidr string, maxConns int, dialTimeout time
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
 	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 
 	sockPath := fmt.Sprintf("%s/p.sock", dir)
 	ln, err := net.Listen("unix", sockPath)
@@ -94,7 +94,7 @@ func newTestServerFull(t *testing.T, cidr string, maxConns int, dialTimeout time
 		close(serveDone)
 	}()
 
-	closeLn := sync.OnceFunc(func() { ln.Close() })
+	closeLn := sync.OnceFunc(func() { _ = ln.Close() })
 	waitServe := func() { <-serveDone }
 
 	t.Cleanup(func() {
@@ -161,7 +161,7 @@ func TestServer_DialsAllowedDestination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial via SOCKS5: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	payload := []byte("ping-from-socks5")
 	if _, err := conn.Write(payload); err != nil {
@@ -183,7 +183,7 @@ func TestServer_RejectsDeniedDestination(t *testing.T) {
 
 	conn, err := socks5Dialer(t, h.sockPath).Dial("tcp", "8.8.8.8:53")
 	if err == nil {
-		conn.Close()
+		_ = conn.Close()
 		t.Fatal("expected error dialing denied destination, got nil")
 	}
 }
@@ -203,14 +203,14 @@ func TestServer_RejectsAtMaxConns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first dial: %v", err)
 	}
-	defer conn1.Close()
+	defer func() { _ = conn1.Close() }()
 
 	waitActiveConns(t, h.srv, 1)
 
 	// 두 번째 dial은 실패 — 서버가 SOCKS5 전에 raw TCP를 끊어 proxy가 EOF/reset을 받음.
 	conn2, err := d.Dial("tcp", echoAddr)
 	if err == nil {
-		conn2.Close()
+		_ = conn2.Close()
 		t.Fatal("expected error dialing at max conns, got nil")
 	}
 
@@ -240,7 +240,7 @@ func TestServer_StatsCountersIncrement(t *testing.T) {
 		t.Errorf("totalDials = %d; want >= 1", total)
 	}
 
-	conn.Close()
+	_ = conn.Close()
 
 	// 종료 후 activeConns가 0으로 떨어지는지 폴링.
 	deadline := time.Now().Add(2 * time.Second)
@@ -303,7 +303,7 @@ func TestServer_ShutdownDrainsActiveConns(t *testing.T) {
 	// 100ms 후 conn 해제 → Shutdown이 drain 가능하도록.
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		conn.Close()
+		_ = conn.Close()
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -337,7 +337,7 @@ func TestServer_ShutdownGraceTimeout(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	// Shutdown 타임아웃 이후까지 conn을 의도적으로 유지; 끝에서 닫아 Serve의 wg.Wait이 풀리게.
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	waitActiveConns(t, h.srv, 1)
 

--- a/cmd/ns-proxy/socks5.go
+++ b/cmd/ns-proxy/socks5.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+
+	socks5 "github.com/things-go/go-socks5"
+	"github.com/things-go/go-socks5/statute"
+)
+
+// cidrRuleSet allows a destination only when its IPv4 address falls in the
+// configured Allowlist. Non-IPv4 destinations are always rejected as
+// defense-in-depth (the Resolver should already strip IPv6, but a malicious or
+// misconfigured client could send a literal IPv6 ATYP).
+type cidrRuleSet struct {
+	allow *Allowlist
+}
+
+// Allow implements socks5.RuleSet. Spec §3 limits supported commands to CONNECT
+// only; BIND and UDP ASSOCIATE are rejected here before the IP/CIDR check.
+// Without this guard, a ASSOCIATE handshake whose hint IP passes the allowlist
+// would let the client relay UDP to arbitrary destinations — the RuleSet is only
+// called once at handshake time, not per-datagram.
+//
+// Note: req.DestAddr.IP is 16-byte (IPv4-in-IPv6) for IPv4 ATYP and 4-byte for
+// domain ATYP. The .To4() call normalises both forms before the allowlist check.
+func (r *cidrRuleSet) Allow(ctx context.Context, req *socks5.Request) (context.Context, bool) {
+	if req.Command != statute.CommandConnect {
+		return ctx, false
+	}
+	ip := req.DestAddr.IP
+	if ip == nil || ip.To4() == nil {
+		return ctx, false
+	}
+	return ctx, r.allow.Contains(ip.To4())
+}
+
+// ipv4OnlyResolver resolves a hostname to its first IPv4 address. IPv6-only
+// hosts return an error, which the lib translates to SOCKS5 reply
+// RepHostUnreachable — it does not silently pick an IPv6 address.
+type ipv4OnlyResolver struct{}
+
+// Resolve implements socks5.NameResolver.
+func (ipv4OnlyResolver) Resolve(ctx context.Context, name string) (context.Context, net.IP, error) {
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip4", name)
+	if err != nil {
+		return ctx, nil, fmt.Errorf("resolve %s: %w", name, err)
+	}
+	for _, ip := range ips {
+		if v4 := ip.To4(); v4 != nil {
+			return ctx, v4, nil
+		}
+	}
+	return ctx, nil, fmt.Errorf("no IPv4 address for %s", name)
+}
+
+// slogLogger adapts a *slog.Logger to the things-go/go-socks5 Logger
+// interface (a single Errorf method).
+type slogLogger struct {
+	log *slog.Logger
+}
+
+// Errorf implements socks5.Logger. Errorf forwards lib log lines to slog. We
+// pre-format with fmt.Sprintf because the lib uses printf-style varargs, not
+// slog-style key/value pairs — collapsing to a single message is the only
+// sensible adapter shape here.
+func (l *slogLogger) Errorf(format string, args ...any) {
+	l.log.Error(fmt.Sprintf(format, args...))
+}
+
+// NewSOCKS5Server wires the lib server with our adapters. Only No-Auth is
+// accepted; Unix socket file permissions are the real authentication boundary.
+// WithDial injects cfg.DialTimeout so that CONNECT to black-holed-but-allowed
+// destinations fails within the configured bound instead of hanging for the
+// kernel default (~75 s).
+func NewSOCKS5Server(cfg *Config, log *slog.Logger) *socks5.Server {
+	dialer := &net.Dialer{Timeout: cfg.DialTimeout}
+	return socks5.NewServer(
+		socks5.WithAuthMethods([]socks5.Authenticator{socks5.NoAuthAuthenticator{}}),
+		socks5.WithResolver(ipv4OnlyResolver{}),
+		socks5.WithRule(&cidrRuleSet{allow: cfg.AllowList}),
+		socks5.WithLogger(&slogLogger{log: log}),
+		socks5.WithDial(dialer.DialContext),
+	)
+}

--- a/cmd/ns-proxy/socks5.go
+++ b/cmd/ns-proxy/socks5.go
@@ -10,22 +10,15 @@ import (
 	"github.com/things-go/go-socks5/statute"
 )
 
-// cidrRuleSet allows a destination only when its IPv4 address falls in the
-// configured Allowlist. Non-IPv4 destinations are always rejected as
-// defense-in-depth (the Resolver should already strip IPv6, but a malicious or
-// misconfigured client could send a literal IPv6 ATYP).
+// cidrRuleSet은 Allowlist에 포함된 IPv4 목적지만 허용.
+// IPv6는 항상 거부 — resolver가 1차로 막지만 literal IPv6 ATYP 우회 대비.
 type cidrRuleSet struct {
 	allow *Allowlist
 }
 
-// Allow implements socks5.RuleSet. Spec §3 limits supported commands to CONNECT
-// only; BIND and UDP ASSOCIATE are rejected here before the IP/CIDR check.
-// Without this guard, a ASSOCIATE handshake whose hint IP passes the allowlist
-// would let the client relay UDP to arbitrary destinations — the RuleSet is only
-// called once at handshake time, not per-datagram.
-//
-// Note: req.DestAddr.IP is 16-byte (IPv4-in-IPv6) for IPv4 ATYP and 4-byte for
-// domain ATYP. The .To4() call normalises both forms before the allowlist check.
+// Allow는 IP/CIDR 검사 전에 CONNECT가 아닌 커맨드를 차단한다.
+// RuleSet은 handshake에 1회만 호출되므로, ASSOCIATE를 통과시키면
+// 이후 UDP 데이터그램은 검증 없이 임의 목적지로 릴레이된다.
 func (r *cidrRuleSet) Allow(ctx context.Context, req *socks5.Request) (context.Context, bool) {
 	if req.Command != statute.CommandConnect {
 		return ctx, false
@@ -37,12 +30,10 @@ func (r *cidrRuleSet) Allow(ctx context.Context, req *socks5.Request) (context.C
 	return ctx, r.allow.Contains(ip.To4())
 }
 
-// ipv4OnlyResolver resolves a hostname to its first IPv4 address. IPv6-only
-// hosts return an error, which the lib translates to SOCKS5 reply
-// RepHostUnreachable — it does not silently pick an IPv6 address.
+// ipv4OnlyResolver는 hostname을 첫 IPv4 주소로 해석.
+// IPv6-only 호스트는 에러 → lib이 RepHostUnreachable 응답.
 type ipv4OnlyResolver struct{}
 
-// Resolve implements socks5.NameResolver.
 func (ipv4OnlyResolver) Resolve(ctx context.Context, name string) (context.Context, net.IP, error) {
 	ips, err := net.DefaultResolver.LookupIP(ctx, "ip4", name)
 	if err != nil {
@@ -56,25 +47,17 @@ func (ipv4OnlyResolver) Resolve(ctx context.Context, name string) (context.Conte
 	return ctx, nil, fmt.Errorf("no IPv4 address for %s", name)
 }
 
-// slogLogger adapts a *slog.Logger to the things-go/go-socks5 Logger
-// interface (a single Errorf method).
+// slogLogger는 lib의 printf 스타일 Errorf를 slog로 어댑트.
 type slogLogger struct {
 	log *slog.Logger
 }
 
-// Errorf implements socks5.Logger. Errorf forwards lib log lines to slog. We
-// pre-format with fmt.Sprintf because the lib uses printf-style varargs, not
-// slog-style key/value pairs — collapsing to a single message is the only
-// sensible adapter shape here.
 func (l *slogLogger) Errorf(format string, args ...any) {
 	l.log.Error(fmt.Sprintf(format, args...))
 }
 
-// NewSOCKS5Server wires the lib server with our adapters. Only No-Auth is
-// accepted; Unix socket file permissions are the real authentication boundary.
-// WithDial injects cfg.DialTimeout so that CONNECT to black-holed-but-allowed
-// destinations fails within the configured bound instead of hanging for the
-// kernel default (~75 s).
+// NewSOCKS5Server: No-Auth만 허용 (Unix 소켓 권한이 실제 인증 경계).
+// DialTimeout으로 black-hole 목적지에서 커널 기본(~75s) 대신 빠르게 실패시킴.
 func NewSOCKS5Server(cfg *Config, log *slog.Logger) *socks5.Server {
 	dialer := &net.Dialer{Timeout: cfg.DialTimeout}
 	return socks5.NewServer(

--- a/cmd/ns-proxy/socks5_test.go
+++ b/cmd/ns-proxy/socks5_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	socks5 "github.com/things-go/go-socks5"
+	"github.com/things-go/go-socks5/statute"
+)
+
+// makeRequestWithCmd builds a *socks5.Request with a command and DestAddr,
+// for testing RuleSet command gating.
+func makeRequestWithCmd(cmd byte, ip net.IP) *socks5.Request {
+	req := &socks5.Request{
+		DestAddr: &statute.AddrSpec{IP: ip},
+	}
+	req.Command = cmd
+	return req
+}
+
+func TestCidrRuleSet_AllowsIPv4InAllowlist(t *testing.T) {
+	al, err := ParseCIDRs("192.168.0.0/16")
+	if err != nil {
+		t.Fatalf("ParseCIDRs: %v", err)
+	}
+	r := &cidrRuleSet{allow: al}
+
+	_, ok := r.Allow(context.Background(), makeRequestWithCmd(statute.CommandConnect, net.ParseIP("192.168.1.10")))
+	if !ok {
+		t.Error("expected allow for 192.168.1.10 (inside 192.168.0.0/16)")
+	}
+}
+
+func TestCidrRuleSet_DeniesIPv4OutsideAllowlist(t *testing.T) {
+	al, err := ParseCIDRs("192.168.0.0/16")
+	if err != nil {
+		t.Fatalf("ParseCIDRs: %v", err)
+	}
+	r := &cidrRuleSet{allow: al}
+
+	_, ok := r.Allow(context.Background(), makeRequestWithCmd(statute.CommandConnect, net.ParseIP("8.8.8.8")))
+	if ok {
+		t.Error("expected deny for 8.8.8.8 (outside 192.168.0.0/16)")
+	}
+}
+
+func TestCidrRuleSet_DeniesIPv6Always(t *testing.T) {
+	al, err := ParseCIDRs("192.168.0.0/16")
+	if err != nil {
+		t.Fatalf("ParseCIDRs: %v", err)
+	}
+	r := &cidrRuleSet{allow: al}
+
+	_, ok := r.Allow(context.Background(), makeRequestWithCmd(statute.CommandConnect, net.ParseIP("2001:db8::1")))
+	if ok {
+		t.Error("expected deny for IPv6 destination (defense-in-depth)")
+	}
+}
+
+func TestCidrRuleSet_DeniesNilIP(t *testing.T) {
+	al, err := ParseCIDRs("192.168.0.0/16")
+	if err != nil {
+		t.Fatalf("ParseCIDRs: %v", err)
+	}
+	r := &cidrRuleSet{allow: al}
+
+	_, ok := r.Allow(context.Background(), makeRequestWithCmd(statute.CommandConnect, nil))
+	if ok {
+		t.Error("expected deny for nil IP")
+	}
+}
+
+func TestCidrRuleSet_DeniesAssociateCommand(t *testing.T) {
+	al, err := ParseCIDRs("192.168.0.0/16")
+	if err != nil {
+		t.Fatalf("ParseCIDRs: %v", err)
+	}
+	r := &cidrRuleSet{allow: al}
+
+	// IP is inside the allowlist, but ASSOCIATE must be rejected regardless.
+	_, ok := r.Allow(context.Background(), makeRequestWithCmd(statute.CommandAssociate, net.ParseIP("192.168.1.10")))
+	if ok {
+		t.Error("expected deny for UDP ASSOCIATE command even with allowed IP")
+	}
+}
+
+func TestCidrRuleSet_DeniesBindCommand(t *testing.T) {
+	al, err := ParseCIDRs("192.168.0.0/16")
+	if err != nil {
+		t.Fatalf("ParseCIDRs: %v", err)
+	}
+	r := &cidrRuleSet{allow: al}
+
+	// IP is inside the allowlist, but BIND must be rejected regardless.
+	_, ok := r.Allow(context.Background(), makeRequestWithCmd(statute.CommandBind, net.ParseIP("192.168.1.10")))
+	if ok {
+		t.Error("expected deny for BIND command even with allowed IP")
+	}
+}
+
+// TestIpv4OnlyResolver_ResolvesLocalhost uses "localhost" rather than a literal
+// IP. The pure-Go resolver (CGO_ENABLED=0) can fail for literal IPs because it
+// tries to resolve them as hostnames; "localhost" is handled by /etc/hosts on
+// both Linux and macOS and always returns an IPv4 address.
+func TestIpv4OnlyResolver_ResolvesLocalhost(t *testing.T) {
+	r := ipv4OnlyResolver{}
+	_, ip, err := r.Resolve(context.Background(), "localhost")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Don't assert exact IP — localhost may be 127.0.0.1 or 127.0.1.1
+	// depending on /etc/hosts.
+	if ip.To4() == nil {
+		t.Errorf("got %v, want IPv4", ip)
+	}
+}
+
+func TestIpv4OnlyResolver_RejectsIPv6Literal(t *testing.T) {
+	r := ipv4OnlyResolver{}
+	_, _, err := r.Resolve(context.Background(), "::1")
+	if err == nil {
+		t.Error("expected error for IPv6-only host, got nil")
+	}
+}
+
+// TODO: the "no IPv4 in resolver results" branch in ipv4OnlyResolver.Resolve is
+// unreachable from these tests because net.DefaultResolver isn't injectable.
+// If the resolver becomes injectable later (e.g. for testability), add a test
+// using a fake that returns only IPv6 addresses.
+
+// ---------- integration tests: command gating via live SOCKS5 server ----------
+//
+// These tests spin up a real NewSOCKS5Server and send raw SOCKS5 bytes through
+// net.Pipe to verify that the server rejects BIND/ASSOCIATE at the protocol
+// level and accepts CONNECT to an allowed destination.
+
+// socks5Handshake sends the SOCKS5 NoAuth greeting and reads the method
+// selection reply. Returns an error if the server did not select NoAuth (0x00).
+func socks5Handshake(conn net.Conn) error {
+	// ClientGreeting: VER=5, NMETHODS=1, METHOD=0x00 (NoAuth)
+	_, err := conn.Write([]byte{0x05, 0x01, 0x00})
+	if err != nil {
+		return err
+	}
+	resp := make([]byte, 2)
+	if _, err := io.ReadFull(conn, resp); err != nil {
+		return err
+	}
+	if resp[0] != 0x05 || resp[1] != 0x00 {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+// socks5CommandReply sends a SOCKS5 command request to 127.0.0.1:<port> using
+// the given command byte and returns the server's reply code (byte [1] of the
+// response).
+func socks5CommandReply(conn net.Conn, cmd byte, ip [4]byte, port uint16) (byte, error) {
+	req := []byte{
+		0x05, cmd, 0x00,
+		0x01, ip[0], ip[1], ip[2], ip[3],
+		byte(port >> 8), byte(port),
+	}
+	if _, err := conn.Write(req); err != nil {
+		return 0, err
+	}
+	// SOCKS5 reply: VER RSP RSV ATYP BND.ADDR(4) BND.PORT(2) = 10 bytes for IPv4
+	resp := make([]byte, 10)
+	if _, err := io.ReadFull(conn, resp); err != nil {
+		return 0, err
+	}
+	return resp[1], nil
+}
+
+// newTestServer creates a NewSOCKS5Server configured with 127.0.0.0/8 allowlist
+// and a short dial timeout (used by integration tests).
+func newTestServer(t *testing.T) *socks5.Server {
+	t.Helper()
+	al, err := ParseCIDRs("127.0.0.0/8")
+	if err != nil {
+		t.Fatalf("ParseCIDRs: %v", err)
+	}
+	cfg := &Config{
+		AllowList:   al,
+		DialTimeout: 2 * time.Second,
+	}
+	return NewSOCKS5Server(cfg, slog.Default())
+}
+
+// runServerConn spins up the server on one end of a net.Pipe connection.
+func runServerConn(srv *socks5.Server, srvConn net.Conn) {
+	_ = srv.ServeConn(srvConn)
+}
+
+func TestNewSOCKS5Server_RejectsAssociate(t *testing.T) {
+	srv := newTestServer(t)
+	client, server := net.Pipe()
+	defer client.Close()
+	go runServerConn(srv, server)
+
+	if err := socks5Handshake(client); err != nil {
+		t.Fatalf("handshake failed: %v", err)
+	}
+	// Send ASSOCIATE for 127.0.0.1:0 — IP is in allowlist but command must be rejected.
+	reply, err := socks5CommandReply(client, statute.CommandAssociate, [4]byte{127, 0, 0, 1}, 0)
+	if err != nil {
+		t.Fatalf("read reply failed: %v", err)
+	}
+	// Expect RepRuleFailure (0x02) — cidrRuleSet.Allow rejects non-CONNECT commands.
+	if reply == statute.RepSuccess {
+		t.Errorf("ASSOCIATE was allowed (reply=0x%02x); expected non-success", reply)
+	}
+}
+
+func TestNewSOCKS5Server_RejectsBind(t *testing.T) {
+	srv := newTestServer(t)
+	client, server := net.Pipe()
+	defer client.Close()
+	go runServerConn(srv, server)
+
+	if err := socks5Handshake(client); err != nil {
+		t.Fatalf("handshake failed: %v", err)
+	}
+	// Send BIND for 127.0.0.1:0 — IP is in allowlist but command must be rejected.
+	reply, err := socks5CommandReply(client, statute.CommandBind, [4]byte{127, 0, 0, 1}, 0)
+	if err != nil {
+		t.Fatalf("read reply failed: %v", err)
+	}
+	if reply == statute.RepSuccess {
+		t.Errorf("BIND was allowed (reply=0x%02x); expected non-success", reply)
+	}
+}
+
+func TestNewSOCKS5Server_AllowsConnect(t *testing.T) {
+	// Start a small in-process echo server to CONNECT to.
+	echo, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listen: %v", err)
+	}
+	defer echo.Close()
+	go func() {
+		conn, err := echo.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		io.Copy(conn, conn) //nolint:errcheck
+	}()
+
+	echoPort := echo.Addr().(*net.TCPAddr).Port
+
+	srv := newTestServer(t)
+	client, server := net.Pipe()
+	defer client.Close()
+	go runServerConn(srv, server)
+
+	if err := socks5Handshake(client); err != nil {
+		t.Fatalf("handshake failed: %v", err)
+	}
+	reply, err := socks5CommandReply(client, statute.CommandConnect, [4]byte{127, 0, 0, 1}, uint16(echoPort))
+	if err != nil {
+		t.Fatalf("read reply failed: %v", err)
+	}
+	if reply != statute.RepSuccess {
+		t.Fatalf("CONNECT denied (reply=0x%02x); expected RepSuccess", reply)
+	}
+
+	// Verify the tunnel works: send a payload and read it back.
+	payload := []byte("hello-ns-proxy")
+	if _, err := client.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(client, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(buf, payload) {
+		t.Errorf("echo mismatch: got %q, want %q", buf, payload)
+	}
+}

--- a/cmd/ns-proxy/socks5_test.go
+++ b/cmd/ns-proxy/socks5_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"testing"
 	"time"
@@ -152,8 +154,9 @@ func socks5CommandReply(conn net.Conn, cmd byte, ip [4]byte, port uint16) (byte,
 	req := []byte{
 		0x05, cmd, 0x00,
 		0x01, ip[0], ip[1], ip[2], ip[3],
-		byte(port >> 8), byte(port),
+		0, 0,
 	}
+	binary.BigEndian.PutUint16(req[8:], port)
 	if _, err := conn.Write(req); err != nil {
 		return 0, err
 	}
@@ -186,7 +189,7 @@ func runServerConn(srv *socks5.Server, srvConn net.Conn) {
 func TestNewSOCKS5Server_RejectsAssociate(t *testing.T) {
 	srv := newTestServer(t)
 	client, server := net.Pipe()
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	go runServerConn(srv, server)
 
 	if err := socks5Handshake(client); err != nil {
@@ -205,7 +208,7 @@ func TestNewSOCKS5Server_RejectsAssociate(t *testing.T) {
 func TestNewSOCKS5Server_RejectsBind(t *testing.T) {
 	srv := newTestServer(t)
 	client, server := net.Pipe()
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	go runServerConn(srv, server)
 
 	if err := socks5Handshake(client); err != nil {
@@ -227,27 +230,30 @@ func TestNewSOCKS5Server_AllowsConnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("echo listen: %v", err)
 	}
-	defer echo.Close()
+	defer func() { _ = echo.Close() }()
 	go func() {
 		conn, err := echo.Accept()
 		if err != nil {
 			return
 		}
-		defer conn.Close()
-		io.Copy(conn, conn) //nolint:errcheck
+		defer func() { _ = conn.Close() }()
+		_, _ = io.Copy(conn, conn)
 	}()
 
 	echoPort := echo.Addr().(*net.TCPAddr).Port
+	if echoPort < 0 || echoPort > math.MaxUint16 {
+		t.Fatalf("echo port out of range: %d", echoPort)
+	}
 
 	srv := newTestServer(t)
 	client, server := net.Pipe()
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	go runServerConn(srv, server)
 
 	if err := socks5Handshake(client); err != nil {
 		t.Fatalf("handshake failed: %v", err)
 	}
-	reply, err := socks5CommandReply(client, statute.CommandConnect, [4]byte{127, 0, 0, 1}, uint16(echoPort))
+	reply, err := socks5CommandReply(client, statute.CommandConnect, [4]byte{127, 0, 0, 1}, uint16(echoPort)) //nolint:gosec // bounds checked above
 	if err != nil {
 		t.Fatalf("read reply failed: %v", err)
 	}

--- a/cmd/ns-proxy/socks5_test.go
+++ b/cmd/ns-proxy/socks5_test.go
@@ -13,8 +13,7 @@ import (
 	"github.com/things-go/go-socks5/statute"
 )
 
-// makeRequestWithCmd builds a *socks5.Request with a command and DestAddr,
-// for testing RuleSet command gating.
+// makeRequestWithCmd는 RuleSet 커맨드 게이팅 검사용 *socks5.Request를 만든다.
 func makeRequestWithCmd(cmd byte, ip net.IP) *socks5.Request {
 	req := &socks5.Request{
 		DestAddr: &statute.AddrSpec{IP: ip},
@@ -82,7 +81,7 @@ func TestCidrRuleSet_DeniesAssociateCommand(t *testing.T) {
 	}
 	r := &cidrRuleSet{allow: al}
 
-	// IP is inside the allowlist, but ASSOCIATE must be rejected regardless.
+	// IP는 allowlist 안이지만 ASSOCIATE는 무조건 거부돼야 함.
 	_, ok := r.Allow(context.Background(), makeRequestWithCmd(statute.CommandAssociate, net.ParseIP("192.168.1.10")))
 	if ok {
 		t.Error("expected deny for UDP ASSOCIATE command even with allowed IP")
@@ -96,25 +95,22 @@ func TestCidrRuleSet_DeniesBindCommand(t *testing.T) {
 	}
 	r := &cidrRuleSet{allow: al}
 
-	// IP is inside the allowlist, but BIND must be rejected regardless.
+	// IP는 allowlist 안이지만 BIND는 무조건 거부돼야 함.
 	_, ok := r.Allow(context.Background(), makeRequestWithCmd(statute.CommandBind, net.ParseIP("192.168.1.10")))
 	if ok {
 		t.Error("expected deny for BIND command even with allowed IP")
 	}
 }
 
-// TestIpv4OnlyResolver_ResolvesLocalhost uses "localhost" rather than a literal
-// IP. The pure-Go resolver (CGO_ENABLED=0) can fail for literal IPs because it
-// tries to resolve them as hostnames; "localhost" is handled by /etc/hosts on
-// both Linux and macOS and always returns an IPv4 address.
+// pure-Go resolver(CGO_ENABLED=0)는 IP literal을 hostname으로 해석하려다 실패할
+// 수 있어 "localhost" 사용 — Linux/macOS 모두 /etc/hosts에서 IPv4로 해석됨.
 func TestIpv4OnlyResolver_ResolvesLocalhost(t *testing.T) {
 	r := ipv4OnlyResolver{}
 	_, ip, err := r.Resolve(context.Background(), "localhost")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Don't assert exact IP — localhost may be 127.0.0.1 or 127.0.1.1
-	// depending on /etc/hosts.
+	// /etc/hosts에 따라 127.0.0.1 또는 127.0.1.1일 수 있어 정확한 IP는 검사 안 함.
 	if ip.To4() == nil {
 		t.Errorf("got %v, want IPv4", ip)
 	}
@@ -128,19 +124,13 @@ func TestIpv4OnlyResolver_RejectsIPv6Literal(t *testing.T) {
 	}
 }
 
-// TODO: the "no IPv4 in resolver results" branch in ipv4OnlyResolver.Resolve is
-// unreachable from these tests because net.DefaultResolver isn't injectable.
-// If the resolver becomes injectable later (e.g. for testability), add a test
-// using a fake that returns only IPv6 addresses.
+// TODO: ipv4OnlyResolver.Resolve의 "결과에 IPv4 없음" 분기는 net.DefaultResolver를
+// 주입할 수 없어 현재 테스트로 못 닿음. 주입 가능해지면 IPv6만 반환하는 fake로 추가.
 
-// ---------- integration tests: command gating via live SOCKS5 server ----------
-//
-// These tests spin up a real NewSOCKS5Server and send raw SOCKS5 bytes through
-// net.Pipe to verify that the server rejects BIND/ASSOCIATE at the protocol
-// level and accepts CONNECT to an allowed destination.
+// ---------- integration tests: 실제 SOCKS5 서버에 raw 바이트로 BIND/ASSOCIATE/CONNECT 검증 ----------
 
-// socks5Handshake sends the SOCKS5 NoAuth greeting and reads the method
-// selection reply. Returns an error if the server did not select NoAuth (0x00).
+// socks5Handshake는 NoAuth greeting을 보내고 method selection 응답을 읽는다.
+// 서버가 NoAuth(0x00)를 선택하지 않으면 에러.
 func socks5Handshake(conn net.Conn) error {
 	// ClientGreeting: VER=5, NMETHODS=1, METHOD=0x00 (NoAuth)
 	_, err := conn.Write([]byte{0x05, 0x01, 0x00})
@@ -157,9 +147,7 @@ func socks5Handshake(conn net.Conn) error {
 	return nil
 }
 
-// socks5CommandReply sends a SOCKS5 command request to 127.0.0.1:<port> using
-// the given command byte and returns the server's reply code (byte [1] of the
-// response).
+// socks5CommandReply는 127.0.0.1:<port>에 대한 커맨드 요청을 보내고 reply byte를 반환.
 func socks5CommandReply(conn net.Conn, cmd byte, ip [4]byte, port uint16) (byte, error) {
 	req := []byte{
 		0x05, cmd, 0x00,
@@ -169,7 +157,7 @@ func socks5CommandReply(conn net.Conn, cmd byte, ip [4]byte, port uint16) (byte,
 	if _, err := conn.Write(req); err != nil {
 		return 0, err
 	}
-	// SOCKS5 reply: VER RSP RSV ATYP BND.ADDR(4) BND.PORT(2) = 10 bytes for IPv4
+	// SOCKS5 reply: VER RSP RSV ATYP BND.ADDR(4) BND.PORT(2) = IPv4의 경우 10 bytes.
 	resp := make([]byte, 10)
 	if _, err := io.ReadFull(conn, resp); err != nil {
 		return 0, err
@@ -177,8 +165,7 @@ func socks5CommandReply(conn net.Conn, cmd byte, ip [4]byte, port uint16) (byte,
 	return resp[1], nil
 }
 
-// newTestServer creates a NewSOCKS5Server configured with 127.0.0.0/8 allowlist
-// and a short dial timeout (used by integration tests).
+// newTestServer는 127.0.0.0/8 allowlist + 짧은 dial timeout으로 구성된 SOCKS5 서버를 만든다.
 func newTestServer(t *testing.T) *socks5.Server {
 	t.Helper()
 	al, err := ParseCIDRs("127.0.0.0/8")
@@ -192,7 +179,6 @@ func newTestServer(t *testing.T) *socks5.Server {
 	return NewSOCKS5Server(cfg, slog.Default())
 }
 
-// runServerConn spins up the server on one end of a net.Pipe connection.
 func runServerConn(srv *socks5.Server, srvConn net.Conn) {
 	_ = srv.ServeConn(srvConn)
 }
@@ -206,12 +192,11 @@ func TestNewSOCKS5Server_RejectsAssociate(t *testing.T) {
 	if err := socks5Handshake(client); err != nil {
 		t.Fatalf("handshake failed: %v", err)
 	}
-	// Send ASSOCIATE for 127.0.0.1:0 — IP is in allowlist but command must be rejected.
+	// IP는 allowlist 안이지만 ASSOCIATE는 거부돼야 함.
 	reply, err := socks5CommandReply(client, statute.CommandAssociate, [4]byte{127, 0, 0, 1}, 0)
 	if err != nil {
 		t.Fatalf("read reply failed: %v", err)
 	}
-	// Expect RepRuleFailure (0x02) — cidrRuleSet.Allow rejects non-CONNECT commands.
 	if reply == statute.RepSuccess {
 		t.Errorf("ASSOCIATE was allowed (reply=0x%02x); expected non-success", reply)
 	}
@@ -226,7 +211,7 @@ func TestNewSOCKS5Server_RejectsBind(t *testing.T) {
 	if err := socks5Handshake(client); err != nil {
 		t.Fatalf("handshake failed: %v", err)
 	}
-	// Send BIND for 127.0.0.1:0 — IP is in allowlist but command must be rejected.
+	// IP는 allowlist 안이지만 BIND는 거부돼야 함.
 	reply, err := socks5CommandReply(client, statute.CommandBind, [4]byte{127, 0, 0, 1}, 0)
 	if err != nil {
 		t.Fatalf("read reply failed: %v", err)
@@ -237,7 +222,7 @@ func TestNewSOCKS5Server_RejectsBind(t *testing.T) {
 }
 
 func TestNewSOCKS5Server_AllowsConnect(t *testing.T) {
-	// Start a small in-process echo server to CONNECT to.
+	// CONNECT 대상으로 in-process echo 서버 기동.
 	echo, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("echo listen: %v", err)
@@ -270,7 +255,7 @@ func TestNewSOCKS5Server_AllowsConnect(t *testing.T) {
 		t.Fatalf("CONNECT denied (reply=0x%02x); expected RepSuccess", reply)
 	}
 
-	// Verify the tunnel works: send a payload and read it back.
+	// 터널 동작 확인: payload 보내고 그대로 받기.
 	payload := []byte("hello-ns-proxy")
 	if _, err := client.Write(payload); err != nil {
 		t.Fatalf("write: %v", err)

--- a/deploy/systemd/ns-proxy.env.example
+++ b/deploy/systemd/ns-proxy.env.example
@@ -16,7 +16,7 @@ RCP_NS_PROXY_ALLOW_CIDR=192.168.0.0/16
 # 동시 연결 한도. 초과 시 conn close (SOCKS handshake 전).
 RCP_NS_PROXY_MAX_CONNS=1024
 
-# upstream dial 타임아웃. 초과 시 SOCKS5 0x06 응답.
+# upstream dial 타임아웃. 초과 시 SOCKS5 0x04 (Host Unreachable) 응답.
 RCP_NS_PROXY_DIAL_TIMEOUT=5s
 
 # SIGTERM 수신 후 활성 연결을 유지하는 시간. 초과 시 강제 close.

--- a/deploy/systemd/ns-proxy.env.example
+++ b/deploy/systemd/ns-proxy.env.example
@@ -1,0 +1,26 @@
+# RCP ns-proxy 환경 설정
+# /etc/rcp/ns-proxy.env 로 복사 후 환경에 맞게 수정.
+# 권한: chown root:rcp /etc/rcp/ns-proxy.env && chmod 0640 /etc/rcp/ns-proxy.env
+
+# 호스트의 OpenStack qrouter namespace 이름.
+# 알아내는 방법: ip netns list | grep '^qrouter-'
+RCP_NS_PROXY_NETNS=qrouter-REPLACE-WITH-UUID
+
+# Unix socket 경로 (RCP API 서버와 동일 그룹이 읽기/쓰기 가능).
+RCP_NS_PROXY_SOCK=/run/rcp/ns-proxy.sock
+
+# 허용된 destination CIDR (콤마 구분 다중 가능).
+# 빈 값이면 시작 거부 (fail closed). 모든 곳을 허용하지 말 것.
+RCP_NS_PROXY_ALLOW_CIDR=192.168.0.0/16
+
+# 동시 연결 한도. 초과 시 conn close (SOCKS handshake 전).
+RCP_NS_PROXY_MAX_CONNS=1024
+
+# upstream dial 타임아웃. 초과 시 SOCKS5 0x06 응답.
+RCP_NS_PROXY_DIAL_TIMEOUT=5s
+
+# SIGTERM 수신 후 활성 연결을 유지하는 시간. 초과 시 강제 close.
+RCP_NS_PROXY_SHUTDOWN_GRACE=30s
+
+# 로그 레벨: debug | info | warn | error
+RCP_NS_PROXY_LOG_LEVEL=info

--- a/deploy/systemd/ns-proxy.service
+++ b/deploy/systemd/ns-proxy.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=RCP ns-proxy (SOCKS5 transport in qrouter netns)
+After=network-online.target openvswitch-switch.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=rcp
+Group=rcp
+
+EnvironmentFile=/etc/rcp/ns-proxy.env
+NetworkNamespacePath=/var/run/netns/${RCP_NS_PROXY_NETNS}
+
+ExecStart=/usr/local/bin/ns-proxy
+
+# /run/rcp/ 자동 생성 + 권한 (재부팅 후에도 유지)
+RuntimeDirectory=rcp
+RuntimeDirectoryMode=0750
+
+# 보안 강화
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/run/rcp
+
+Restart=on-failure
+RestartSec=2s
+
+# graceful shutdown (앱 grace 30s + 약간의 여유)
+TimeoutStopSec=35s
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/lib/pq v1.12.3
 	github.com/things-go/go-socks5 v0.1.1
 	golang.org/x/crypto v0.49.0
+	golang.org/x/net v0.52.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.272.0
 	modernc.org/sqlite v1.47.0
@@ -71,7 +72,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260311181403-84a4fc48630c // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gophercloud/gophercloud v1.14.1
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.12.3
+	github.com/things-go/go-socks5 v0.1.1
 	golang.org/x/crypto v0.49.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.272.0

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/things-go/go-socks5 v0.1.1 h1:48hy9cHEXPKeG91G/g4n8zW4uynzPUQy/FkcrJ7r5AY=
+github.com/things-go/go-socks5 v0.1.1/go.mod h1:1YBHVYG7Oli5ae+Pwkp630cPAwY1pjUPmohO1n0Emg0=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=


### PR DESCRIPTION
## 배경

RCP API 서버 호스트의 default netns에는 OpenStack tenant 망(`10.0.0.0/24`)으로 가는 라우팅이 없다. 그래서 인스턴스에 닿으려면 floating IP를 받아야 했고, 이 방식은 외부 노출 표면이 늘고 IP 풀 비용이 들고 인스턴스마다 매번 할당해야 한다.

이 PR은 호스트의 qrouter netns 안에서 도는 작은 SOCKS5 프록시 데몬을 추가해서, API 서버가 Unix 소켓 한 줄로 tenant 인스턴스에 floating IP 없이 닿을 수 있게 한다.

## 구조

```
[Host default netns]                       [qrouter-XXX netns]
  rcp-api ──/run/rcp/ns-proxy.sock──▶ ns-proxy ──▶ 10.0.0.29:22
                                      (SOCKS5)     (tenant 인스턴스)
```

- `cmd/ns-proxy/` — Go 데몬. `github.com/things-go/go-socks5`를 RuleSet/Resolver/Dial 어댑터로 감쌌다.
- `deploy/systemd/ns-proxy.service` — `NetworkNamespacePath=`로 qrouter netns에 진입, `RuntimeDirectory=rcp` + mode `0750`으로 소켓 디렉터리 격리.
- `deploy/systemd/ns-proxy.env.example` — 6개 환경변수 템플릿.

## 보안 게이트

- **Fail-closed allowlist**: `RCP_NS_PROXY_ALLOW_CIDR` 미설정/빈 값/형식 오류면 시작 거부.
- **CONNECT만 허용**: BIND·UDP ASSOCIATE는 IP 검사 전에 차단. RuleSet이 handshake 1회만 호출되어, ASSOCIATE를 흘리면 이후 UDP는 검증 없이 임의 목적지로 흘러감.
- **IPv4 only**: resolver가 IPv4만 고름 + literal IPv6 ATYP도 RuleSet에서 또 거부 (이중 차단).
- **No-Auth + Unix 소켓 권한**: 인증은 OS 파일 권한으로. `0660` 소켓 + `0750` 디렉터리, `rcp` 그룹만 접근.
- **MaxConns semaphore**: 슬롯 만석이면 SOCKS5 협상 전에 TCP 단절 + denied 카운터.
- **Graceful shutdown**: SIGTERM 후 `RCP_NS_PROXY_SHUTDOWN_GRACE` 동안 in-flight drain, 그 후 강제 종료.

## 테스트

### 단위 테스트
`cmd/ns-proxy/*_test.go` 28개 케이스. raw SOCKS5 wire 바이트로 BIND/ASSOCIATE 거부 검증, `golang.org/x/net/proxy` 통과 end-to-end CONNECT, MaxConns 거부, Shutdown drain/grace timeout, stats 카운터, Config 엣지 케이스(빈 CIDR, 음수 MaxConns, 잘못된 duration, relative path).

```bash
go test -count=1 ./cmd/ns-proxy/...
# ok 0.9s
```

### 실 환경 smoke test
`return-compute-1` 호스트, `qrouter-851bf8f2-6ff2-487a-9987-c874475fe4ff`에서 수동 검증.

```bash
sudo RCP_NS_PROXY_ALLOW_CIDR=10.0.0.0/24 \
     RCP_NS_PROXY_SOCK=/tmp/ns-proxy-test/ns-proxy.sock \
     RCP_NS_PROXY_LOG_LEVEL=debug \
     ip netns exec qrouter-851bf8f2-... ./ns-proxy
```

다른 터미널에서 socat으로 Unix→TCP bridge 후 nc:

```bash
# proxy 거침 → 성공
nc -X 5 -x localhost:1080 -w 5 10.0.0.29 22
# SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.15

# proxy 안 거치고 직접 → 실패
nc -w 3 10.0.0.29 22
# (빈 결과, exit 1)
```

이 둘의 대비로 "host default netns에선 못 닿는데 ns-proxy 경유로는 닿는다"가 증명됨. floating IP 없이 tenant 인스턴스 도달이 의도대로 동작.

## 변경 파일

- 신규
  - `cmd/ns-proxy/{main,server,socks5,config,allowlist}.go` + 각 `_test.go`
  - `deploy/systemd/{ns-proxy.service, ns-proxy.env.example}`
- 변경
  - `go.mod`, `go.sum`: `github.com/things-go/go-socks5 v0.1.1` 추가, `golang.org/x/net` indirect → direct (테스트가 직접 사용)

---

## 다음 작업자 전달사항

이번 PR은 데몬만 들어감, ssh, http통합이 추가로 진행되어야 함

### 1. SSH 통합 (가장 가까운 다음 단계)
API 서버가 인스턴스에 SSH 명령을 보낼 때 ns-proxy 경유로 보내도록. 대략 이런 모양이 된다:

```go
forward := &unixForwarder{path: "/run/rcp/ns-proxy.sock"}
sd, _ := proxy.SOCKS5("tcp", "unused", nil, forward)

tcpConn, err := sd.Dial("tcp", instanceIP+":22")
if err != nil { return err }

sshConn, chans, reqs, err := ssh.NewClientConn(tcpConn, instanceIP+":22", sshCfg)
client := ssh.NewClient(sshConn, chans, reqs)
```

`server_test.go:114-119`의 `unixDialer`가 그대로 참고할 만한 forward dialer 구현이다 (테스트에서 같은 패턴을 씀).

체크리스트:
- [ ] API 서버 패키지에 `Dialer` 추상화 추가 (기존 `net.Dial` 대체)
- [ ] 소켓 경로를 환경설정에서 받기 (기본값 `/run/rcp/ns-proxy.sock`)
- [ ] API 서버 user를 `rcp` 보조 그룹에 추가: `sudo usermod -aG rcp <api-user>`
- [ ] 인스턴스 보안그룹에서 22번이 tenant 망에 열려 있는지 확인

### 2. 운영 배포 (호스트 한 번만)
```bash
sudo install -m 0755 ns-proxy /usr/local/bin/
sudo install -m 0644 deploy/systemd/ns-proxy.service /etc/systemd/system/
sudo install -d -o root -g rcp -m 0750 /etc/rcp
sudo install -m 0640 -o root -g rcp deploy/systemd/ns-proxy.env.example /etc/rcp/ns-proxy.env
sudo $EDITOR /etc/rcp/ns-proxy.env   # NETNS UUID + ALLOW_CIDR
sudo systemctl daemon-reload
sudo systemctl enable --now ns-proxy
```

### 3. 현재 PR구현의 한계 (`server.go:79`)
`things-go/go-socks5`에 handshake-only read deadline 훅이 없다. TCP만 맺고 SOCKS5 greeting을 안 보내는 클라이언트가 sem 슬롯을 무한 점유 가능. Unix 소켓이라 외부 노출은 없고 같은 호스트의 `rcp` 그룹 내부 위협만 해당하지만, timeoutConn wrapper로 wrapping하거나 upstream lib에 PR을 보내 마무리하는 편이 깔끔하다. 별도 이슈로 분리.
