### PR TITLE
feat: CD 파이프라인 정비 및 .env/systemd IaC 관리 + ns-proxy 배포 자동화

### DIFF
--- a/.github/workflows/deploy-ns-proxy.yml
+++ b/.github/workflows/deploy-ns-proxy.yml
@@ -1,0 +1,115 @@
+name: ns-proxy CD Pipeline
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'cmd/ns-proxy/**'
+      - 'deploy/systemd/ns-proxy.service'
+      - '.github/workflows/deploy-ns-proxy.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Build
+        run: GOOS=linux GOARCH=amd64 go build -v -o ns-proxy ./cmd/ns-proxy
+
+      - name: Transfer artifacts (SCP)
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          source: "ns-proxy,deploy/systemd/ns-proxy.service"
+          target: "/tmp/ns-proxy-deploy"
+
+      - name: Install binary
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          script: |
+            set -euo pipefail
+            sudo install -m 0755 -o root -g root \
+              /tmp/ns-proxy-deploy/ns-proxy \
+              /usr/local/bin/ns-proxy
+
+      - name: Write env file
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          envs: RCP_NS_PROXY_ALLOW_CIDR
+          script: |
+            set -euo pipefail
+
+            NETNS=$(ip netns list | awk '/^qrouter-/ {print $1; exit}')
+            if [ -z "$NETNS" ]; then
+              echo "ERROR: qrouter netns not found on host" >&2
+              exit 1
+            fi
+
+            sudo install -d -o root -g root -m 0755 /etc/rcp
+
+            sudo tee /etc/rcp/ns-proxy.env > /dev/null <<EOF
+            RCP_NS_PROXY_NETNS=$NETNS
+            RCP_NS_PROXY_SOCK=/run/rcp/ns-proxy.sock
+            RCP_NS_PROXY_ALLOW_CIDR=$RCP_NS_PROXY_ALLOW_CIDR
+            RCP_NS_PROXY_MAX_CONNS=1024
+            RCP_NS_PROXY_DIAL_TIMEOUT=5s
+            RCP_NS_PROXY_SHUTDOWN_GRACE=30s
+            RCP_NS_PROXY_LOG_LEVEL=info
+            EOF
+            sudo chown root:return /etc/rcp/ns-proxy.env
+            sudo chmod 0640 /etc/rcp/ns-proxy.env
+
+      - name: Install systemd unit
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          script: |
+            set -euo pipefail
+            sudo install -m 0644 -o root -g root \
+              /tmp/ns-proxy-deploy/deploy/systemd/ns-proxy.service \
+              /etc/systemd/system/ns-proxy.service
+            sudo systemctl daemon-reload
+            sudo systemctl enable ns-proxy
+
+      - name: Restart service
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          script: |
+            set -euo pipefail
+            sudo systemctl restart ns-proxy
+
+      - name: Cleanup deploy artifacts
+        if: always()
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          script: |
+            rm -rf /tmp/ns-proxy-deploy

--- a/.github/workflows/deploy-ns-proxy.yml
+++ b/.github/workflows/deploy-ns-proxy.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           go-version: '1.26'
 
+      - name: Run Tests
+        run: go test ./... -v
+
       - name: Build
         run: GOOS=linux GOARCH=amd64 go build -v -o ns-proxy ./cmd/ns-proxy
 
@@ -56,13 +59,13 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_KEY }}
-          envs: RCP_NS_PROXY_ALLOW_CIDR
+          envs: RCP_NS_PROXY_ALLOW_CIDR,RCP_NS_PROXY_ROUTER_ID
           script: |
             set -euo pipefail
 
-            NETNS=$(ip netns list | awk '/^qrouter-/ {print $1; exit}')
-            if [ -z "$NETNS" ]; then
-              echo "ERROR: qrouter netns not found on host" >&2
+            NETNS="qrouter-${RCP_NS_PROXY_ROUTER_ID}"
+            if ! ip netns list | awk '{print $1}' | grep -qx "$NETNS"; then
+              echo "ERROR: netns $NETNS not found on host" >&2
               exit 1
             fi
 
@@ -112,4 +115,5 @@ jobs:
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_KEY }}
           script: |
+            set -euo pipefail
             rm -rf /tmp/ns-proxy-deploy

--- a/.github/workflows/deploy-ns-proxy.yml
+++ b/.github/workflows/deploy-ns-proxy.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Build
         run: GOOS=linux GOARCH=amd64 go build -v -o ns-proxy ./cmd/ns-proxy
 
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ns-proxy-${{ github.sha }}
+          path: ns-proxy
+          retention-days: 1
+
       - name: Transfer artifacts (SCP)
         uses: appleboy/scp-action@v0.1.7
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           go-version: '1.26'
 
+      - name: Run Tests
+        run: go test ./... -v
+
       - name: Build
         run: GOOS=linux GOARCH=amd64 go build -v -o server ./cmd/api/main.go
 
@@ -56,21 +59,21 @@ jobs:
             mkdir -p ~/rcp-server
             umask 077
             {
-              printf 'RCP_JWT_SECRET=%s\n' "$RCP_JWT_SECRET"
-              printf 'OS_AUTH_URL=%s\n' "$OS_AUTH_URL"
-              printf 'OS_USERNAME=%s\n' "$OS_USERNAME"
-              printf 'OS_PASSWORD=%s\n' "$OS_PASSWORD"
-              printf 'OS_PROJECT_NAME=%s\n' "$OS_PROJECT_NAME"
-              printf 'OS_USER_DOMAIN_NAME=%s\n' "$OS_USER_DOMAIN_NAME"
-              printf 'OS_PROJECT_ID=%s\n' "$OS_PROJECT_ID"
-              printf 'CF_ACCESS_CLIENT_ID=%s\n' "$CF_ACCESS_CLIENT_ID"
-              printf 'CF_ACCESS_CLIENT_SECRET=%s\n' "$CF_ACCESS_CLIENT_SECRET"
-              printf 'GG_OAUTH_CLIENT=%s\n' "$GG_OAUTH_CLIENT"
-              printf 'GG_OAUTH_SECRET=%s\n' "$GG_OAUTH_SECRET"
-              printf 'GG_REDIRECT_URL=%s\n' "$GG_REDIRECT_URL"
-              printf 'DB_DRIVER=%s\n' "$DB_DRIVER"
-              printf 'DB_DSN=%s\n' "$DB_DSN"
-              printf 'PORT=%s\n' "$PORT"
+              printf '%s\n' "RCP_JWT_SECRET=$RCP_JWT_SECRET"
+              printf '%s\n' "OS_AUTH_URL=$OS_AUTH_URL"
+              printf '%s\n' "OS_USERNAME=$OS_USERNAME"
+              printf '%s\n' "OS_PASSWORD=$OS_PASSWORD"
+              printf '%s\n' "OS_PROJECT_NAME=$OS_PROJECT_NAME"
+              printf '%s\n' "OS_USER_DOMAIN_NAME=$OS_USER_DOMAIN_NAME"
+              printf '%s\n' "OS_PROJECT_ID=$OS_PROJECT_ID"
+              printf '%s\n' "CF_ACCESS_CLIENT_ID=$CF_ACCESS_CLIENT_ID"
+              printf '%s\n' "CF_ACCESS_CLIENT_SECRET=$CF_ACCESS_CLIENT_SECRET"
+              printf '%s\n' "GG_OAUTH_CLIENT=$GG_OAUTH_CLIENT"
+              printf '%s\n' "GG_OAUTH_SECRET=$GG_OAUTH_SECRET"
+              printf '%s\n' "GG_REDIRECT_URL=$GG_REDIRECT_URL"
+              printf '%s\n' "DB_DRIVER=$DB_DRIVER"
+              printf '%s\n' "DB_DSN=$DB_DSN"
+              printf '%s\n' "PORT=$PORT"
             } > ~/rcp-server/.env
             chmod 0600 ~/rcp-server/.env
 
@@ -106,4 +109,5 @@ jobs:
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_KEY }}
           script: |
+            set -euo pipefail
             rm -rf /tmp/rcp-deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,31 +19,91 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26' # 최신 버전 반영
-
-      - name: Run Tests
-        run: go test ./... -v # 배포 전 테스트 (지성님 제안)
+          go-version: '1.26'
 
       - name: Build
         run: GOOS=linux GOARCH=amd64 go build -v -o server ./cmd/api/main.go
 
-      - name: Transfer Binary (SCP)
-        uses: appleboy/scp-action@v0.1.7 # 버전 명시
+      - name: Transfer artifacts (SCP)
+        uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.SERVER_HOST }} # Tailscale IP(100.x.y.z) 권장
+          host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
-          key: ${{ secrets.SERVER_KEY }}   # Key 방식 선택 (Password 제거 가능)
-          source: "server"
-          target: "~/rcp-server/"
+          key: ${{ secrets.SERVER_KEY }}
+          source: "server,deploy/systemd/rcp-server.service"
+          target: "/tmp/rcp-deploy"
 
-      - name: Restart Service (SSH)
-        uses: appleboy/ssh-action@v0.1.10 # 버전 명시
+      - name: Install binary
+        uses: appleboy/ssh-action@v0.1.10
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_KEY }}
           script: |
-            cd ~/rcp-server
-            chmod +x server
-            # systemd 서비스 재시작 (없으면 새로 등록 필요)
-            sudo systemctl restart rcp-server || (echo "Service not found, using nohup for now" && nohup ./server > app.log 2>&1 &)
+            set -euo pipefail
+            mkdir -p ~/rcp-server
+            install -m 0755 /tmp/rcp-deploy/server ~/rcp-server/server
+
+      - name: Write .env file
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          envs: RCP_JWT_SECRET,OS_AUTH_URL,OS_USERNAME,OS_PASSWORD,OS_PROJECT_NAME,OS_USER_DOMAIN_NAME,OS_PROJECT_ID,CF_ACCESS_CLIENT_ID,CF_ACCESS_CLIENT_SECRET,GG_OAUTH_CLIENT,GG_OAUTH_SECRET,GG_REDIRECT_URL,DB_DRIVER,DB_DSN,PORT
+          script: |
+            set -euo pipefail
+            mkdir -p ~/rcp-server
+            umask 077
+            {
+              printf 'RCP_JWT_SECRET=%s\n' "$RCP_JWT_SECRET"
+              printf 'OS_AUTH_URL=%s\n' "$OS_AUTH_URL"
+              printf 'OS_USERNAME=%s\n' "$OS_USERNAME"
+              printf 'OS_PASSWORD=%s\n' "$OS_PASSWORD"
+              printf 'OS_PROJECT_NAME=%s\n' "$OS_PROJECT_NAME"
+              printf 'OS_USER_DOMAIN_NAME=%s\n' "$OS_USER_DOMAIN_NAME"
+              printf 'OS_PROJECT_ID=%s\n' "$OS_PROJECT_ID"
+              printf 'CF_ACCESS_CLIENT_ID=%s\n' "$CF_ACCESS_CLIENT_ID"
+              printf 'CF_ACCESS_CLIENT_SECRET=%s\n' "$CF_ACCESS_CLIENT_SECRET"
+              printf 'GG_OAUTH_CLIENT=%s\n' "$GG_OAUTH_CLIENT"
+              printf 'GG_OAUTH_SECRET=%s\n' "$GG_OAUTH_SECRET"
+              printf 'GG_REDIRECT_URL=%s\n' "$GG_REDIRECT_URL"
+              printf 'DB_DRIVER=%s\n' "$DB_DRIVER"
+              printf 'DB_DSN=%s\n' "$DB_DSN"
+              printf 'PORT=%s\n' "$PORT"
+            } > ~/rcp-server/.env
+            chmod 0600 ~/rcp-server/.env
+
+      - name: Install systemd unit
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          script: |
+            set -euo pipefail
+            sudo install -m 0644 -o root -g root \
+              /tmp/rcp-deploy/deploy/systemd/rcp-server.service \
+              /etc/systemd/system/rcp-server.service
+            sudo systemctl daemon-reload
+            sudo systemctl enable rcp-server
+
+      - name: Restart service
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          script: |
+            set -euo pipefail
+            sudo systemctl restart rcp-server
+
+      - name: Cleanup deploy artifacts
+        if: always()
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          script: |
+            rm -rf /tmp/rcp-deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,32 +56,37 @@ jobs:
 
       - name: Write .env file
         uses: appleboy/ssh-action@v0.1.10
+        env:
+          ENV_LIST: RCP_JWT_SECRET,OS_AUTH_URL,OS_USERNAME,OS_PASSWORD,OS_PROJECT_NAME,OS_USER_DOMAIN_NAME,OS_PROJECT_ID,CF_ACCESS_CLIENT_ID,CF_ACCESS_CLIENT_SECRET,GG_OAUTH_CLIENT,GG_OAUTH_SECRET,GG_REDIRECT_URL,DB_DRIVER,DB_DSN,PORT
+          RCP_JWT_SECRET: ${{ secrets.RCP_JWT_SECRET }}
+          OS_AUTH_URL: ${{ secrets.OS_AUTH_URL }}
+          OS_USERNAME: ${{ secrets.OS_USERNAME }}
+          OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
+          OS_PROJECT_NAME: ${{ secrets.OS_PROJECT_NAME }}
+          OS_USER_DOMAIN_NAME: ${{ secrets.OS_USER_DOMAIN_NAME }}
+          OS_PROJECT_ID: ${{ secrets.OS_PROJECT_ID }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+          GG_OAUTH_CLIENT: ${{ secrets.GG_OAUTH_CLIENT }}
+          GG_OAUTH_SECRET: ${{ secrets.GG_OAUTH_SECRET }}
+          GG_REDIRECT_URL: ${{ secrets.GG_REDIRECT_URL }}
+          DB_DRIVER: ${{ secrets.DB_DRIVER }}
+          DB_DSN: ${{ secrets.DB_DSN }}
+          PORT: ${{ secrets.PORT }}
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_KEY }}
-          envs: RCP_JWT_SECRET,OS_AUTH_URL,OS_USERNAME,OS_PASSWORD,OS_PROJECT_NAME,OS_USER_DOMAIN_NAME,OS_PROJECT_ID,CF_ACCESS_CLIENT_ID,CF_ACCESS_CLIENT_SECRET,GG_OAUTH_CLIENT,GG_OAUTH_SECRET,GG_REDIRECT_URL,DB_DRIVER,DB_DSN,PORT
+          envs: ${{ env.ENV_LIST }}
           script: |
             set -euo pipefail
             mkdir -p ~/rcp-server
             umask 077
-            {
-              printf '%s\n' "RCP_JWT_SECRET=$RCP_JWT_SECRET"
-              printf '%s\n' "OS_AUTH_URL=$OS_AUTH_URL"
-              printf '%s\n' "OS_USERNAME=$OS_USERNAME"
-              printf '%s\n' "OS_PASSWORD=$OS_PASSWORD"
-              printf '%s\n' "OS_PROJECT_NAME=$OS_PROJECT_NAME"
-              printf '%s\n' "OS_USER_DOMAIN_NAME=$OS_USER_DOMAIN_NAME"
-              printf '%s\n' "OS_PROJECT_ID=$OS_PROJECT_ID"
-              printf '%s\n' "CF_ACCESS_CLIENT_ID=$CF_ACCESS_CLIENT_ID"
-              printf '%s\n' "CF_ACCESS_CLIENT_SECRET=$CF_ACCESS_CLIENT_SECRET"
-              printf '%s\n' "GG_OAUTH_CLIENT=$GG_OAUTH_CLIENT"
-              printf '%s\n' "GG_OAUTH_SECRET=$GG_OAUTH_SECRET"
-              printf '%s\n' "GG_REDIRECT_URL=$GG_REDIRECT_URL"
-              printf '%s\n' "DB_DRIVER=$DB_DRIVER"
-              printf '%s\n' "DB_DSN=$DB_DSN"
-              printf '%s\n' "PORT=$PORT"
-            } > ~/rcp-server/.env
+            : > ~/rcp-server/.env
+            IFS=',' read -ra _VARS <<< "${{ env.ENV_LIST }}"
+            for _v in "${_VARS[@]}"; do
+              printf '%s=%s\n' "$_v" "${!_v}" >> ~/rcp-server/.env
+            done
             chmod 0600 ~/rcp-server/.env
 
       - name: Install systemd unit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Build
         run: GOOS=linux GOARCH=amd64 go build -v -o server ./cmd/api/main.go
 
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rcp-server-${{ github.sha }}
+          path: server
+          retention-days: 1
+
       - name: Transfer artifacts (SCP)
         uses: appleboy/scp-action@v0.1.7
         with:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ go generate ./cmd/api
 - `http://localhost:8080/docs`
 - `http://localhost:8080/openapi.yaml`
 
+## Deployment
+
+`main` 브랜치 머지 시 `compute-1` 호스트로 자동 배포됩니다.
+
+- `.github/workflows/deploy.yml` — rcp-server (매 머지마다)
+- `.github/workflows/deploy-ns-proxy.yml` — ns-proxy (`cmd/ns-proxy/**`나 `deploy/systemd/ns-proxy.service` 변경 시, 또는 `workflow_dispatch` 수동 trigger)
+
+### 기여할 때 알아둘 것
+
+- **새 환경변수 추가** — `cmd/api/main.go`의 `os.Getenv` + `deploy.yml`의 `envs:`/`printf` 블록 + GitHub Secrets, 세 군데를 같이 갱신해야 합니다
+- **systemd unit 변경** — `deploy/systemd/*.service`는 IaC로 관리됩니다. 머지하면 호스트의 `/etc/systemd/system/`에 자동 install + `daemon-reload` + `restart`가 일어나 즉시 운영에 반영됩니다
+- **ent schema 변경** — `NewEntClient`가 시작 시 `Schema.Create`를 자동 호출하므로 서버 재시작이 곧 마이그레이션입니다. prod DB와 호환되는 변경인지 확인 필요
+- **ns-proxy 의존 코드 변경** — `internal/` 등 공유 코드를 바꿨다면 ns-proxy 워크플로는 자동 trigger되지 않으니 GitHub Actions에서 `Run workflow`로 수동 실행
+- **OpenStack 라우터(qrouter) UUID 변경** — `RCP_NS_PROXY_ROUTER_ID` Secret 갱신 후 ns-proxy 워크플로 수동 재실행
+- **운영 로그 조회** — `ssh return@compute-1 journalctl -u rcp-server -f` (ns-proxy도 동일 패턴)
+- **로컬 개발** — 프로젝트 루트의 `.env`를 godotenv가 로드합니다. 운영에서는 systemd `EnvironmentFile`이 같은 역할을 하므로 동작이 일치합니다
+
 ## Notes
 
 - OpenStack 호출은 Cloudflare Access 헤더가 포함된 HTTP 클라이언트를 통해 수행됩니다.

--- a/deploy/systemd/ns-proxy.service
+++ b/deploy/systemd/ns-proxy.service
@@ -5,8 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=rcp
-Group=rcp
+User=return
+Group=return
 
 EnvironmentFile=/etc/rcp/ns-proxy.env
 NetworkNamespacePath=/var/run/netns/${RCP_NS_PROXY_NETNS}

--- a/deploy/systemd/rcp-server.service
+++ b/deploy/systemd/rcp-server.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=RCP Server Go Application
+After=network.target
+
+[Service]
+User=return
+WorkingDirectory=/home/return/rcp-server
+ExecStart=/home/return/rcp-server/server
+Restart=always
+RestartSec=3
+StandardOutput=append:/home/return/rcp-server/app.log
+StandardError=append:/home/return/rcp-server/app.log
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/rcp-server.service
+++ b/deploy/systemd/rcp-server.service
@@ -4,12 +4,18 @@ After=network.target
 
 [Service]
 User=return
+Group=return
 WorkingDirectory=/home/return/rcp-server
+EnvironmentFile=/home/return/rcp-server/.env
 ExecStart=/home/return/rcp-server/server
 Restart=always
 RestartSec=3
-StandardOutput=append:/home/return/rcp-server/app.log
-StandardError=append:/home/return/rcp-server/app.log
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=true
+ProtectSystem=full
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### 배경

기존 CD에 두 가지 구멍이 있어서 정리했습니다.

1. `~/rcp-server/.env`와 `rcp-server.service`가 호스트에서 수동 관리 → 형상관리 밖
2. ns-proxy는 자동 배포 파이프라인이 아예 없음 → 수동 SCP/`systemctl` 운영

### 작업 설명

**rcp-server CD (`deploy.yml`)**
- `.env`를 GitHub Secrets에서 자동 생성
- `rcp-server.service`를 레포로 옮겨 매 배포 시 install + `daemon-reload`
- `nohup` fallback 제거
- 배포 단계를 5개로 분리 (binary / env / unit / restart / cleanup)
- 빌드 산출물 artifact 업로드 (1일 보존, 사고 시 재배포용)

**rcp-server systemd unit (신규)**
- 보안 옵션: `NoNewPrivileges`, `ProtectSystem=full`, `PrivateTmp`
- `EnvironmentFile` 명시 (godotenv는 로컬 개발 호환용으로 유지)
- 로그를 file → `journal`로 전환

**ns-proxy CD (`deploy-ns-proxy.yml` 신규)**
- `cmd/ns-proxy/**` 변경 시만 트리거 + `workflow_dispatch`
- NETNS UUID는 Secret으로 받고 호스트 존재 검증
- `User/Group`을 `rcp` → `return`으로 통일
- 빌드 산출물 artifact 업로드 (1일 보존)

### 변경 파일

```
.github/workflows/deploy.yml             (수정)
.github/workflows/deploy-ns-proxy.yml    (신규)
deploy/systemd/rcp-server.service        (신규)
deploy/systemd/ns-proxy.service          (수정)
```

---

### 머지 전 해야 할 것

#### 1. GitHub Secrets 17개 등록

**rcp-server (15)** — 호스트의 `~/rcp-server/.env` 값 그대로
```
RCP_JWT_SECRET
OS_AUTH_URL, OS_USERNAME, OS_PASSWORD, OS_PROJECT_NAME,
OS_USER_DOMAIN_NAME, OS_PROJECT_ID
CF_ACCESS_CLIENT_ID, CF_ACCESS_CLIENT_SECRET
GG_OAUTH_CLIENT, GG_OAUTH_SECRET, GG_REDIRECT_URL
DB_DRIVER, DB_DSN, PORT
```

**ns-proxy (2)**
```
RCP_NS_PROXY_ALLOW_CIDR    (예: 192.168.0.0/16)
RCP_NS_PROXY_ROUTER_ID     (qrouter- 뒤 UUID, 아래 명령으로 확인)
```
```bash
ssh return@compute-1 'ip netns list | grep qrouter-'
```

#### 2. 호스트 sudo NOPASSWD

`/etc/sudoers.d/return`:
```
return ALL=(root) NOPASSWD: /usr/bin/install, /usr/bin/tee, /bin/systemctl, /bin/chown, /bin/chmod
```
저장 후 `sudo visudo -c`.

#### 3. 첫 머지 전 백업 (권장)
```bash
ssh return@compute-1 '
  cp ~/rcp-server/server ~/rcp-server/server.bak
  cp ~/rcp-server/.env ~/rcp-server/.env.bak
  sudo cp /etc/systemd/system/rcp-server.service{,.bak}
'
```

---

### 머지 후 확인

```bash
sudo systemctl status rcp-server
journalctl -u rcp-server -n 50
```

ns-proxy는 paths 필터로 자동 트리거 안 됨 → Actions 탭에서 `Run workflow` 수동 실행.

---

### 다음 라운드 (이번 PR 미포함, 합의됨)

- DB 마이그레이션 가드 (`RCP_AUTO_MIGRATE` 환경변수) — 현재 `NewEntClient`에서 매 시작 시 자동 호출 중, 운영 시작 후 가드 도입 검토
- 헬스체크 + 자동 롤백
- `environment: production` 승인 게이트
- 빌드 메타 ldflags

### 운영 시작 후 주의

- ns-proxy `restart`는 활성 SOCKS 연결을 끊습니다
- NETNS UUID 변경 시 → Secret 갱신 후 `workflow_dispatch` 재실행
- `.env` 키 추가 시 → `cmd/api/main.go` + `deploy.yml` + GitHub Secrets 세 군데
- ent schema 변경 코드가 머지되면 서버 재시작 시 자동 마이그레이션 적용됨 (현재 가드 없음)
