### PR TITLE
fix(ns-proxy): 배포 env 및 netns 이름 처리 수정

### DIFF
--- a/.github/workflows/deploy-ns-proxy.yml
+++ b/.github/workflows/deploy-ns-proxy.yml
@@ -62,6 +62,9 @@ jobs:
 
       - name: Write env file
         uses: appleboy/ssh-action@v0.1.10
+        env:
+          RCP_NS_PROXY_ALLOW_CIDR: ${{ secrets.RCP_NS_PROXY_ALLOW_CIDR }}
+          RCP_NS_PROXY_ROUTER_ID: ${{ secrets.RCP_NS_PROXY_ROUTER_ID }}
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
@@ -70,7 +73,7 @@ jobs:
           script: |
             set -euo pipefail
 
-            NETNS="qrouter-${RCP_NS_PROXY_ROUTER_ID}"
+            NETNS="${RCP_NS_PROXY_ROUTER_ID}"
             if ! ip netns list | awk '{print $1}' | grep -qx "$NETNS"; then
               echo "ERROR: netns $NETNS not found on host" >&2
               exit 1


### PR DESCRIPTION
## 요약

ns-proxy 배포 워크플로우에서 SSH 원격 스크립트가 필요한 Secret 값을 참조하지 못하고, netns 이름도 실제 Secret 값과 다르게 조합될 수 있는 부분을 수정했습니다.

## 변경 사항

- `deploy-ns-proxy.yml`의 `Write env file` SSH step에 `RCP_NS_PROXY_ALLOW_CIDR`, `RCP_NS_PROXY_ROUTER_ID` env 전달 추가
- 원격 스크립트에서 `RCP_NS_PROXY_ROUTER_ID` 값을 그대로 netns 이름으로 사용하도록 변경
- 호스트의 `ip netns list` 검증이 Secret에 저장된 실제 netns 이름 기준으로 동작하도록 정리

## 배경

`appleboy/ssh-action`의 원격 script 안에서 GitHub Secrets 값을 직접 참조하려면 step env로 넘겨야 합니다. 또한 기존 스크립트는 `qrouter-` prefix를 한 번 더 붙여서, Secret에 이미 전체 netns 이름이 들어있는 경우 배포 검증이 실패할 수 있었습니다.

## 테스트

- [x] 변경 파일 diff 확인
- [x] 커밋 후 working tree clean 확인
- [ ] Actions 탭에서 `deploy-ns-proxy` workflow 수동 실행 확인