### PR TITLE
fix(ns-proxy): 배포 unit netns 경로 치환 추가

### DIFF
--- a/.github/workflows/deploy-ns-proxy.yml
+++ b/.github/workflows/deploy-ns-proxy.yml
@@ -95,14 +95,22 @@ jobs:
 
       - name: Install systemd unit
         uses: appleboy/ssh-action@v0.1.10
+        env:
+          RCP_NS_PROXY_ROUTER_ID: ${{ secrets.RCP_NS_PROXY_ROUTER_ID }}
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_KEY }}
+          envs: RCP_NS_PROXY_ROUTER_ID
           script: |
             set -euo pipefail
+
+            NETNS="${RCP_NS_PROXY_ROUTER_ID}"
+
             sudo install -m 0644 -o root -g root \
               /tmp/ns-proxy-deploy/deploy/systemd/ns-proxy.service \
+              /etc/systemd/system/ns-proxy.service
+            sudo sed -i "s|/var/run/netns/\${RCP_NS_PROXY_NETNS}|/var/run/netns/${NETNS}|g" \
               /etc/systemd/system/ns-proxy.service
             sudo systemctl daemon-reload
             sudo systemctl enable ns-proxy


### PR DESCRIPTION
## 요약

ns-proxy 배포 워크플로우에서 systemd unit 설치 후 `NetworkNamespacePath`가 실제 router netns 경로를 바라보도록 치환하는 단계를 추가했습니다.

## 변경 사항

- `Install systemd unit` SSH step에 `RCP_NS_PROXY_ROUTER_ID` env 전달 추가
- 원격 스크립트에서 Secret 값을 `NETNS`로 받아 systemd unit의 netns placeholder 치환
- unit 설치 후 `daemon-reload`, `enable` 전에 `/var/run/netns/...` 경로가 실제 netns를 가리키도록 정리

## 배경

`deploy/systemd/ns-proxy.service`는 배포 환경마다 달라지는 netns 이름을 placeholder로 들고 있습니다. 배포 시점에 GitHub Secret의 router/netns 값을 반영하지 않으면 systemd가 존재하지 않는 netns 경로로 ns-proxy를 실행할 수 있어, unit 설치 단계에서 명시적으로 치환하도록 했습니다.

## 테스트

- [x] 현재 diff 확인
- [x] 커밋 후 working tree clean 확인
- [ ] Actions 탭에서 `deploy-ns-proxy` workflow 수동 실행 확인