### PR TITLE
fix(auth): me 응답에 access token 포함

### DIFF
--- a/internal/domain/auth/handler.go
+++ b/internal/domain/auth/handler.go
@@ -109,9 +109,10 @@ func (h *Handler) Me(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, MeResponse{
-		ID:    user.ID,
-		Name:  user.Name,
-		Email: user.Email,
+		ID:          user.ID,
+		Name:        user.Name,
+		Email:       user.Email,
+		AccessToken: token,
 	})
 }
 

--- a/internal/domain/auth/types.go
+++ b/internal/domain/auth/types.go
@@ -20,9 +20,10 @@ type User struct {
 }
 
 type MeResponse struct {
-	ID    uuid.UUID `json:"id"`
-	Email string    `json:"email"`
-	Name  string    `json:"name"`
+	ID          uuid.UUID `json:"id"`
+	Email       string    `json:"email"`
+	Name        string    `json:"name"`
+	AccessToken string    `json:"access_token"`
 }
 
 type ErrorResponse struct {


### PR DESCRIPTION
## 변경 사항

- `/api/v1/auth/me` 응답에 `access_token` 추가
- `MeResponse` 타입에 `AccessToken` 필드 추가

## 배경

PR #44에서 현재 사용자 조회 API를 추가했지만, 프론트에서 기존 인증 흐름과 맞춰 사용할 access token 응답이 빠져 있어 보완합니다.

## Test plan

- [x] `go test ./...`
