### PR TITLE
fix: prune stale compute instances during list sync

### DIFF
--- a/internal/domain/compute/service.go
+++ b/internal/domain/compute/service.go
@@ -142,6 +142,7 @@ func (s *Service) GetInstances(ctx context.Context, ownerID uuid.UUID) ([]Instan
 
 	res := make([]InstanceDetailResponse, 0, len(dbInstances))
 	staleIDs := make([]string, 0)
+
 	for _, inst := range dbInstances {
 		srv, ok := serverMap[inst.OpenstackID]
 		if !ok {
@@ -161,16 +162,22 @@ func (s *Service) GetInstances(ctx context.Context, ownerID uuid.UUID) ([]Instan
 			Created:    inst.Created,
 		})
 	}
-
-	for _, id := range staleIDs {
-		if err := s.repo.DeleteByOpenstackID(ctx, ownerID, id); err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrInstanceOperationFailed, err)
-		}
+	if err := s.pruneStaleInstances(ctx, ownerID, staleIDs); err != nil {
+		return nil, err
 	}
 
 	return res, nil
 }
 
+func (s *Service) pruneStaleInstances(ctx context.Context, ownerID uuid.UUID, staleIDs []string) error {
+	for _, id := range staleIDs {
+		if err := s.repo.DeleteByOpenstackID(ctx, ownerID, id); err != nil {
+			return fmt.Errorf("%w: %v", ErrInstanceOperationFailed, err)
+		}
+	}
+
+	return nil
+}
 // GetInstanceDetail은 DB(소유권), OpenStack 상태, diagnostics를 병렬로 읽어 조합하여 반환합니다.
 func (s *Service) GetInstanceDetail(ctx context.Context, ownerID uuid.UUID, id string) (*InstanceDetailResponse, error) {
 	var (

--- a/internal/domain/compute/service.go
+++ b/internal/domain/compute/service.go
@@ -178,6 +178,7 @@ func (s *Service) pruneStaleInstances(ctx context.Context, ownerID uuid.UUID, st
 
 	return nil
 }
+
 // GetInstanceDetail은 DB(소유권), OpenStack 상태, diagnostics를 병렬로 읽어 조합하여 반환합니다.
 func (s *Service) GetInstanceDetail(ctx context.Context, ownerID uuid.UUID, id string) (*InstanceDetailResponse, error) {
 	var (

--- a/internal/domain/compute/service.go
+++ b/internal/domain/compute/service.go
@@ -141,8 +141,14 @@ func (s *Service) GetInstances(ctx context.Context, ownerID uuid.UUID) ([]Instan
 	}
 
 	res := make([]InstanceDetailResponse, 0, len(dbInstances))
+	staleIDs := make([]string, 0)
 	for _, inst := range dbInstances {
-		srv := serverMap[inst.OpenstackID]
+		srv, ok := serverMap[inst.OpenstackID]
+		if !ok {
+			staleIDs = append(staleIDs, inst.OpenstackID)
+			continue
+		}
+
 		fixedIP, floatingIP := extractServerIPs(&srv)
 		res = append(res, InstanceDetailResponse{
 			ID:         inst.OpenstackID,
@@ -155,6 +161,13 @@ func (s *Service) GetInstances(ctx context.Context, ownerID uuid.UUID) ([]Instan
 			Created:    inst.Created,
 		})
 	}
+
+	for _, id := range staleIDs {
+		if err := s.repo.DeleteByOpenstackID(ctx, ownerID, id); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrInstanceOperationFailed, err)
+		}
+	}
+
 	return res, nil
 }
 

--- a/internal/domain/compute/service_test.go
+++ b/internal/domain/compute/service_test.go
@@ -555,6 +555,73 @@ func TestServiceCreateInstance(t *testing.T) {
 	})
 }
 
+func TestServiceGetInstances(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns only instances that still exist in OpenStack and prunes stale DB rows", func(t *testing.T) {
+		var deletedIDs []string
+		repo := &fakeRepo{
+			listByOwnerFn: func(_ context.Context, _ uuid.UUID) ([]Instance, error) {
+				return []Instance{
+					{OpenstackID: "server-1", Name: "vm-1", ImageID: "image-1", FlavorID: "flavor-1"},
+					{OpenstackID: "server-stale", Name: "old-vm", ImageID: "image-2", FlavorID: "flavor-2"},
+				}, nil
+			},
+			deleteByOpenstackIDFn: func(_ context.Context, _ uuid.UUID, id string) error {
+				deletedIDs = append(deletedIDs, id)
+				return nil
+			},
+		}
+		client := &fakeClient{
+			fetchInstancesFn: func() ([]Server, error) {
+				return []Server{{ID: "server-1", Status: "ACTIVE"}}, nil
+			},
+			fetchFlavorsFn: func() ([]Flavor, error) {
+				return []Flavor{
+					{ID: "flavor-1", Name: "m1.small", VCPUs: 1, RAM: 1024},
+					{ID: "flavor-2", Name: "m1.medium", VCPUs: 2, RAM: 2048},
+				}, nil
+			},
+		}
+
+		svc := NewService(client, repo, "project-1")
+		res, err := svc.GetInstances(ctx, testOwnerID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(res) != 1 {
+			t.Fatalf("expected 1 live instance, got %d: %+v", len(res), res)
+		}
+		if res[0].ID != "server-1" || res[0].Status != "ACTIVE" {
+			t.Fatalf("unexpected live instance response: %+v", res[0])
+		}
+		if !reflect.DeepEqual(deletedIDs, []string{"server-stale"}) {
+			t.Fatalf("expected stale server to be deleted, got %#v", deletedIDs)
+		}
+	})
+
+	t.Run("returns operation failed when pruning stale DB rows fails", func(t *testing.T) {
+		repo := &fakeRepo{
+			listByOwnerFn: func(_ context.Context, _ uuid.UUID) ([]Instance, error) {
+				return []Instance{{OpenstackID: "server-stale"}}, nil
+			},
+			deleteByOpenstackIDFn: func(_ context.Context, _ uuid.UUID, _ string) error {
+				return errors.New("db delete failed")
+			},
+		}
+		client := &fakeClient{
+			fetchInstancesFn: func() ([]Server, error) { return []Server{}, nil },
+			fetchFlavorsFn:   func() ([]Flavor, error) { return []Flavor{}, nil },
+		}
+
+		svc := NewService(client, repo, "project-1")
+		_, err := svc.GetInstances(ctx, testOwnerID)
+		if !errors.Is(err, ErrInstanceOperationFailed) {
+			t.Fatalf("expected ErrInstanceOperationFailed, got %v", err)
+		}
+	})
+}
+
 func TestServiceDeleteInstance(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## 요약

- 인스턴스 목록 응답에 OpenStack에 실제 존재하는 인스턴스만 포함하도록 수정

- OpenStack server list에 없는 DB 인스턴스 row를 목록 조회 시 DB에서도 삭제

- stale DB row 정리 및 정리 실패 케이스에 대한 서비스 테스트 추가

## 상세

`GET /compute/instances`는 이제 OpenStack을 실제 인스턴스 존재 여부의 기준으로 사용합니다.

DB는 기존처럼 소유권과 생성 시점의 메타데이터를 저장하는 용도로 사용하되, DB에는 남아 있지만 OpenStack server list에 없는 인스턴스는 응답에서 제외하고 DB에서도 삭제합니다.

이 정리 작업은 배포 직후 백그라운드에서 자동 실행되는 것이 아니라, 인스턴스 목록 API가 호출될 때 수행됩니다. 따라서 사용자가 인스턴스 목록 페이지를 열거나 프론트엔드가 목록 API를 호출하면 그 시점에 동기화됩니다.

## 주의 사항

- OpenStack `server list` 결과를 기준으로 DB row를 삭제하므로, OpenStack 조회가 정상적으로 성공한 경우에만 stale 여부를 판단합니다.
- OpenStack 목록 조회 자체가 실패하면 기존처럼 인스턴스 목록 API도 실패하며, DB row 삭제는 수행되지 않습니다.
- DB 정리 중 삭제 실패가 발생하면 API는 에러를 반환합니다. 일부 stale row가 남아 있을 수 있으므로 로그 확인이 필요합니다.
- 이 변경은 목록 조회 시점의 동기화이며, 별도 백그라운드 정리 작업이나 주기적 배치는 포함하지 않습니다.
- DB에는 있지만 OpenStack에 없는 인스턴스는 복구 대상이 아니라 삭제 대상으로 간주합니다.

## 테스트

- `go test ./internal/domain/compute`