### PR TITLE
fix(compute): mapping correct instance creation date from OpenStack

### DIFF
--- a/internal/domain/compute/client.go
+++ b/internal/domain/compute/client.go
@@ -98,7 +98,7 @@ func (c *Client) FetchInstances() ([]Server, error) {
 	}
 
 	result := make([]Server, len(raw))
-	
+
 	for i, s := range raw {
 		fmt.Printf("Instance %s Created At: %v\n", s.Name, s.Created)
 		result[i] = Server{

--- a/internal/domain/compute/client.go
+++ b/internal/domain/compute/client.go
@@ -1,8 +1,6 @@
 package compute
 
 import (
-	"fmt"
-
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/diagnostics"
@@ -100,7 +98,6 @@ func (c *Client) FetchInstances() ([]Server, error) {
 	result := make([]Server, len(raw))
 
 	for i, s := range raw {
-		fmt.Printf("Instance %s Created At: %v\n", s.Name, s.Created)
 		result[i] = Server{
 			ID:         s.ID,
 			Name:       s.Name,

--- a/internal/domain/compute/client.go
+++ b/internal/domain/compute/client.go
@@ -1,6 +1,8 @@
 package compute
 
 import (
+	"fmt"
+
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/diagnostics"
@@ -96,13 +98,16 @@ func (c *Client) FetchInstances() ([]Server, error) {
 	}
 
 	result := make([]Server, len(raw))
+	
 	for i, s := range raw {
+		fmt.Printf("Instance %s Created At: %v\n", s.Name, s.Created)
 		result[i] = Server{
 			ID:         s.ID,
 			Name:       s.Name,
 			Status:     s.Status,
 			Addresses:  s.Addresses,
 			AccessIPv4: s.AccessIPv4,
+			Created:    s.Created,
 		}
 	}
 	return result, nil
@@ -125,6 +130,7 @@ func (c *Client) FetchInstance(id string) (*Server, error) {
 		Status:     raw.Status,
 		Addresses:  raw.Addresses,
 		AccessIPv4: raw.AccessIPv4,
+		Created:    raw.Created,
 	}, nil
 }
 

--- a/internal/domain/compute/service.go
+++ b/internal/domain/compute/service.go
@@ -159,7 +159,7 @@ func (s *Service) GetInstances(ctx context.Context, ownerID uuid.UUID) ([]Instan
 			Flavor:     flavorMap[inst.FlavorID],
 			FixedIP:    fixedIP,
 			FloatingIP: floatingIP,
-			Created:    inst.Created,
+			Created:    srv.Created,
 		})
 	}
 	if err := s.pruneStaleInstances(ctx, ownerID, staleIDs); err != nil {
@@ -233,7 +233,7 @@ func (s *Service) GetInstanceDetail(ctx context.Context, ownerID uuid.UUID, id s
 		FixedIP:    fixedIP,
 		FloatingIP: floatingIP,
 		Usage:      extractUsageStats(diag),
-		Created:    inst.Created,
+		Created:    srv.Created,
 	}, nil
 }
 

--- a/internal/domain/compute/types.go
+++ b/internal/domain/compute/types.go
@@ -43,7 +43,7 @@ type Server struct {
 	KeyName        string
 	SecurityGroups []map[string]any
 	AccessIPv4     string
-	Created        time.Time
+	Created        time.Time `json:"created"`
 }
 
 type NetworkID struct {


### PR DESCRIPTION
📋 개요 (Description)
인스턴스 목록 및 상세 페이지에서 생성 날짜(Created)가 -로 표시되거나 0001-01-01로 나오던 문제를 해결했습니다.
🛠️ 변경 사항 (Changes)
	1.	Backend (Go)
•	internal/compute/client.go: FetchInstances 및 FetchInstance 함수에서 OpenStack API 응답의 Created 필드를 구조체에 매핑하도록 수정했습니다.
•	internal/compute/service.go: GetInstances 서비스 로직에서 DB 데이터 대신 OpenStack에서 전달받은 srv.Created 데이터를 사용하도록 변경했습니다.
•	Server 구조체: JSON 직렬화 시 프론트엔드와 이름을 맞추기 위해 Created 필드에 `json:"created"` 태그를 추가했습니다.