### PR TITLE
fix(openstack): enable provider token reauth

### DIFF
--- a/internal/infrastructure/openstack/client.go
+++ b/internal/infrastructure/openstack/client.go
@@ -24,6 +24,7 @@ func NewProviderClient(cfg ProviderConfig) (*gophercloud.ProviderClient, error) 
 		Password:         cfg.Password,
 		TenantName:       cfg.ProjectName,
 		DomainName:       cfg.DomainName,
+		AllowReauth:      true,
 	}
 
 	provider, err := openstack.NewClient(opts.IdentityEndpoint)


### PR DESCRIPTION
## 요약
- OpenStack provider client에 Gophercloud `AllowReauth` 설정을 활성화했습니다.
- Keystone token 만료 후에도 API 서버가 자동으로 재인증할 수 있도록 했습니다.

## 배경
API 서버는 장시간 유지되는 OpenStack provider client를 사용합니다.  
기존에는 재인증이 비활성화되어 있어 최초 발급된 Keystone token이 만료되면 OpenStack API 요청이 `Authentication failed`로 실패할 수 있었습니다.

## Test plan
- [x] `go test ./...`
- [x] `rcp-server` 재시작
- [x] 재시작 직후 `/api/v1/compute/flavors?available=true` 동작 확인
- [x] Keystone token 만료 시간 이후에도 동일 endpoint가 계속 동작하는지 확인