### PR TITLE
feat(storage): add folder archive downloads

### DIFF
--- a/GUIDELINE.md
+++ b/GUIDELINE.md
@@ -150,8 +150,9 @@ main.go → infrastructure 클라이언트 생성 → App 조립 → 라우터 �
 | POST | `/api/v1/storage/containers` | CreateContainer | container 생성 |
 | DELETE | `/api/v1/storage/containers/:name` | DeleteContainer | container 삭제 (`?force=true`로 강제 삭제) |
 | GET | `/api/v1/storage/containers/:name/objects` | ListObjects | object 목록 조회 |
-| POST | `/api/v1/storage/containers/:name/objects` | UploadObject | 파일 업로드 (multipart/form-data, key=`file`) |
+| POST | `/api/v1/storage/containers/:name/objects/*key` | UploadObject | 파일 업로드 (multipart/form-data, key=`file`) |
 | GET | `/api/v1/storage/containers/:name/objects/*key` | DownloadObject | 파일 다운로드 (스트리밍) |
+| GET | `/api/v1/storage/containers/:name/archive?prefix=path/` | ArchiveObjects | prefix 아래 object를 zip으로 다운로드 |
 | DELETE | `/api/v1/storage/containers/:name/objects/*key` | DeleteObject | 파일 삭제 |
 
 ---

--- a/internal/domain/storage/handler.go
+++ b/internal/domain/storage/handler.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -26,6 +27,7 @@ func (h *Handler) InitRoutes(rg *gin.RouterGroup) {
 		g.POST("/containers", h.CreateContainer)
 		g.DELETE("/containers/:name", h.DeleteContainer)
 		g.GET("/containers/:name/objects", h.ListObjects)
+		g.GET("/containers/:name/archive", h.ArchiveObjects)
 		g.POST("/containers/:name/objects/*key", h.UploadObject)
 		g.GET("/containers/:name/objects/*key", h.DownloadObject)
 		g.DELETE("/containers/:name/objects/*key", h.DeleteObject)
@@ -174,6 +176,33 @@ func (h *Handler) DownloadObject(c *gin.Context) {
 	}
 }
 
+func (h *Handler) ArchiveObjects(c *gin.Context) {
+	id, ok := api.OwnerID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, api.ErrorResponse{Error: "unauthorized"})
+		return
+	}
+
+	containerName := c.Param("name")
+	prefix := normalizeObjectPrefix(c.Query("prefix"))
+
+	c.Header(api.HeaderContentType, "application/zip")
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", archiveFilename(containerName, prefix)))
+	if err := h.Svc.ArchiveObjects(c.Request.Context(), id, containerName, prefix, c.Writer); err != nil {
+		if c.Writer.Written() {
+			_ = c.Error(err)
+			return
+		}
+		switch {
+		case errors.Is(err, ErrContainerNotFound), errors.Is(err, ErrObjectPrefixNotFound):
+			c.JSON(http.StatusNotFound, api.ErrorResponse{Error: err.Error()})
+		default:
+			c.JSON(http.StatusInternalServerError, api.ErrorResponse{Error: err.Error()})
+		}
+		return
+	}
+}
+
 func (h *Handler) DeleteObject(c *gin.Context) {
 	id, ok := api.OwnerID(c)
 	if !ok {
@@ -194,4 +223,17 @@ func (h *Handler) DeleteObject(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusNoContent)
+}
+
+func archiveFilename(containerName, prefix string) string {
+	base := strings.TrimSuffix(prefix, "/")
+	if base == "" {
+		base = containerName
+	} else if idx := strings.LastIndex(base, "/"); idx >= 0 {
+		base = base[idx+1:]
+	}
+	if base == "" {
+		base = "objects"
+	}
+	return base + ".zip"
 }

--- a/internal/domain/storage/handler_test.go
+++ b/internal/domain/storage/handler_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -316,6 +317,68 @@ func TestHandlerDownloadObject(t *testing.T) {
 		}
 		if w.Body.String() != "file content" {
 			t.Fatalf("unexpected body: %q", w.Body.String())
+		}
+	})
+}
+
+func TestHandlerArchiveObjects(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("streams zip archive for prefix", func(t *testing.T) {
+		client := &fakeStorageClient{
+			listObjectsFn: func(_ string) ([]ObjectInfo, error) {
+				return []ObjectInfo{
+					{Name: "docs/readme.txt"},
+					{Name: "docs/nested/a.txt"},
+					{Name: "other.txt"},
+				}, nil
+			},
+			downloadObjectFn: func(_, objectName string, w io.Writer) error {
+				_, _ = io.WriteString(w, "content:"+objectName)
+				return nil
+			},
+		}
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return &Container{Name: "my-bucket", OpenstackName: testContainerUUID}, nil
+			},
+		}
+
+		req := httptest.NewRequest(
+			http.MethodGet,
+			api.BasePath+"/storage/containers/my-bucket/archive?prefix=docs%2F",
+			nil,
+		)
+		w := httptest.NewRecorder()
+		r := gin.New()
+		v1 := r.Group(api.BasePath)
+		withTestUser(v1)
+		newTestHandler(client, repo).InitRoutes(v1)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		if got := w.Header().Get(api.HeaderContentType); got != "application/zip" {
+			t.Fatalf("expected application/zip content type, got %q", got)
+		}
+		if got := w.Header().Get("Content-Disposition"); got != `attachment; filename="docs.zip"` {
+			t.Fatalf("unexpected content disposition: %q", got)
+		}
+
+		zr, err := zip.NewReader(bytes.NewReader(w.Body.Bytes()), int64(w.Body.Len()))
+		if err != nil {
+			t.Fatalf("zip.NewReader: %v", err)
+		}
+		got := make(map[string]bool, len(zr.File))
+		for _, f := range zr.File {
+			got[f.Name] = true
+		}
+		if !got["docs/readme.txt"] || !got["docs/nested/a.txt"] {
+			t.Fatalf("missing expected zip entries: %v", got)
+		}
+		if got["other.txt"] {
+			t.Fatal("archive included object outside prefix")
 		}
 	})
 }

--- a/internal/domain/storage/service.go
+++ b/internal/domain/storage/service.go
@@ -1,10 +1,12 @@
 package storage
 
 import (
+	"archive/zip"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -14,6 +16,7 @@ var (
 	ErrContainerNotFound      = errors.New("container not found")
 	ErrContainerNotEmpty      = errors.New("container not empty, use force=true to delete all")
 	ErrContainerAlreadyExists = errors.New("container name already in use")
+	ErrObjectPrefixNotFound   = errors.New("object prefix not found")
 	ErrStorageOperationFailed = errors.New("storage operation failed")
 )
 
@@ -150,6 +153,54 @@ func (s *Service) DownloadObject(ctx context.Context, ownerID uuid.UUID, contain
 	return nil
 }
 
+func (s *Service) ArchiveObjects(ctx context.Context, ownerID uuid.UUID, containerName, prefix string, w io.Writer) error {
+	c, err := s.resolveContainer(ctx, ownerID, containerName)
+	if err != nil {
+		return err
+	}
+
+	prefix = normalizeObjectPrefix(prefix)
+	objs, err := s.client.ListObjects(c.OpenstackName.String())
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrStorageOperationFailed, err)
+	}
+
+	matches := make([]ObjectInfo, 0, len(objs))
+	for _, obj := range objs {
+		if prefix == "" || strings.HasPrefix(obj.Name, prefix) {
+			matches = append(matches, obj)
+		}
+	}
+	if len(matches) == 0 {
+		return ErrObjectPrefixNotFound
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].Name < matches[j].Name
+	})
+
+	zw := zip.NewWriter(w)
+	for _, obj := range matches {
+		entryName, err := safeZipEntryName(obj.Name)
+		if err != nil {
+			_ = zw.Close()
+			return fmt.Errorf("%w: %v", ErrStorageOperationFailed, err)
+		}
+		entry, err := zw.Create(entryName)
+		if err != nil {
+			_ = zw.Close()
+			return fmt.Errorf("%w: %v", ErrStorageOperationFailed, err)
+		}
+		if err := s.client.DownloadObject(c.OpenstackName.String(), obj.Name, entry); err != nil {
+			_ = zw.Close()
+			return fmt.Errorf("%w: %v", ErrStorageOperationFailed, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return fmt.Errorf("%w: %v", ErrStorageOperationFailed, err)
+	}
+	return nil
+}
+
 func (s *Service) DeleteObject(ctx context.Context, ownerID uuid.UUID, containerName, objectName string) error {
 	c, err := s.resolveContainer(ctx, ownerID, containerName)
 	if err != nil {
@@ -170,4 +221,25 @@ func (s *Service) resolveContainer(ctx context.Context, ownerID uuid.UUID, name 
 		return nil, ErrContainerNotFound
 	}
 	return c, nil
+}
+
+func normalizeObjectPrefix(prefix string) string {
+	prefix = strings.TrimLeft(prefix, "/")
+	if prefix != "" && !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	return prefix
+}
+
+func safeZipEntryName(name string) (string, error) {
+	cleaned := strings.TrimLeft(name, "/")
+	if cleaned == "" {
+		return "", fmt.Errorf("empty object name")
+	}
+	for _, segment := range strings.Split(cleaned, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return "", fmt.Errorf("unsafe object name %q", name)
+		}
+	}
+	return cleaned, nil
 }

--- a/internal/domain/storage/service_test.go
+++ b/internal/domain/storage/service_test.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -320,6 +322,98 @@ func TestServiceUploadObject(t *testing.T) {
 		err := svc.UploadObject(ctx, testOwnerID, "missing", "file.txt", nil, "")
 		if !errors.Is(err, ErrContainerNotFound) {
 			t.Fatalf("expected ErrContainerNotFound, got %v", err)
+		}
+	})
+}
+
+func TestServiceArchiveObjects(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("streams zip for objects under prefix", func(t *testing.T) {
+		objectsByName := map[string]string{
+			"docs/readme.txt":    "readme",
+			"docs/nested/a.txt":  "nested",
+			"images/ignored.txt": "ignored",
+		}
+		client := &fakeStorageClient{
+			listObjectsFn: func(containerName string) ([]ObjectInfo, error) {
+				if containerName != testContainerUUID.String() {
+					t.Fatalf("expected Swift container %q, got %q", testContainerUUID, containerName)
+				}
+				return []ObjectInfo{
+					{Name: "images/ignored.txt"},
+					{Name: "docs/nested/a.txt"},
+					{Name: "docs/readme.txt"},
+				}, nil
+			},
+			downloadObjectFn: func(containerName, objectName string, w io.Writer) error {
+				if containerName != testContainerUUID.String() {
+					t.Fatalf("expected Swift container %q, got %q", testContainerUUID, containerName)
+				}
+				_, err := io.WriteString(w, objectsByName[objectName])
+				return err
+			},
+		}
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return &Container{Name: "my-bucket", OpenstackName: testContainerUUID}, nil
+			},
+		}
+
+		var buf bytes.Buffer
+		svc := NewService(client, repo)
+		if err := svc.ArchiveObjects(ctx, testOwnerID, "my-bucket", "docs/", &buf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+		if err != nil {
+			t.Fatalf("zip.NewReader: %v", err)
+		}
+		got := map[string]string{}
+		for _, f := range zr.File {
+			rc, err := f.Open()
+			if err != nil {
+				t.Fatalf("open zip entry %q: %v", f.Name, err)
+			}
+			content, err := io.ReadAll(rc)
+			_ = rc.Close()
+			if err != nil {
+				t.Fatalf("read zip entry %q: %v", f.Name, err)
+			}
+			got[f.Name] = string(content)
+		}
+
+		if len(got) != 2 {
+			t.Fatalf("expected 2 archived objects, got %d: %v", len(got), got)
+		}
+		if got["docs/readme.txt"] != "readme" {
+			t.Fatalf("expected docs/readme.txt content, got %q", got["docs/readme.txt"])
+		}
+		if got["docs/nested/a.txt"] != "nested" {
+			t.Fatalf("expected docs/nested/a.txt content, got %q", got["docs/nested/a.txt"])
+		}
+		if _, ok := got["images/ignored.txt"]; ok {
+			t.Fatal("archive included object outside prefix")
+		}
+	})
+
+	t.Run("returns ErrObjectPrefixNotFound when prefix has no objects", func(t *testing.T) {
+		client := &fakeStorageClient{
+			listObjectsFn: func(_ string) ([]ObjectInfo, error) {
+				return []ObjectInfo{{Name: "other/file.txt"}}, nil
+			},
+		}
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return &Container{Name: "my-bucket", OpenstackName: testContainerUUID}, nil
+			},
+		}
+
+		svc := NewService(client, repo)
+		err := svc.ArchiveObjects(ctx, testOwnerID, "my-bucket", "missing/", io.Discard)
+		if !errors.Is(err, ErrObjectPrefixNotFound) {
+			t.Fatalf("expected ErrObjectPrefixNotFound, got %v", err)
 		}
 	})
 }

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -33,6 +33,7 @@ func TestNewRouterRegistersComputeRoutes(t *testing.T) {
 	var foundAuthorizedKeys bool
 	var foundStorageContainers bool
 	var foundStorageUploadObject bool
+	var foundStorageArchiveObjects bool
 
 	for _, route := range routes {
 		if route.Method == http.MethodGet && route.Path == api.BasePath+"/auth/me" {
@@ -59,6 +60,9 @@ func TestNewRouterRegistersComputeRoutes(t *testing.T) {
 		if route.Method == http.MethodPost && route.Path == api.BasePath+"/storage/containers/:name/objects/*key" {
 			foundStorageUploadObject = true
 		}
+		if route.Method == http.MethodGet && route.Path == api.BasePath+"/storage/containers/:name/archive" {
+			foundStorageArchiveObjects = true
+		}
 	}
 
 	if !foundFlavors {
@@ -84,6 +88,9 @@ func TestNewRouterRegistersComputeRoutes(t *testing.T) {
 	}
 	if !foundStorageUploadObject {
 		t.Fatalf("%s %s/storage/containers/:name/objects route was not registered", http.MethodPost, api.BasePath)
+	}
+	if !foundStorageArchiveObjects {
+		t.Fatalf("%s %s/storage/containers/:name/archive route was not registered", http.MethodGet, api.BasePath)
 	}
 }
 


### PR DESCRIPTION
## Summary

  - `GET /api/v1/storage/containers/:name/archive?prefix=...` 엔드포인트를
  추가해 object prefix 단위 폴더를 zip으로 다운로드할 수 있게 했습니다.
  - Swift object들을 zip으로 스트리밍하면서 기존 object key 경로를 보존합
  니다.
  - archive 다운로드에 대한 service, handler, router 테스트를 추가했습니
  다.
  - 실제 업로드 라우트와 맞지 않던 storage API 문서를 `objects/*key` 기준
  으로 수정했습니다.

  ## Test Plan

  - `go test -count=1 ./...`
<img width="2912" height="1286" alt="image" src="https://github.com/user-attachments/assets/1825b9e2-8db6-4e0f-8d8c-b7dc7c4f007c" />
