### PR TITLE
fix(storage): normalize object content type

### DIFF
--- a/internal/domain/storage/client.go
+++ b/internal/domain/storage/client.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
@@ -14,6 +15,10 @@ import (
 
 type Client struct {
 	provider *gophercloud.ProviderClient
+}
+
+type responseHeaderWriter interface {
+	Header() http.Header
 }
 
 func NewClient(provider *gophercloud.ProviderClient) *Client {
@@ -88,6 +93,7 @@ func (c *Client) DownloadObject(containerName, objectName string, w io.Writer) e
 		return result.Err
 	}
 	defer func() { _ = result.Body.Close() }()
+	copyDownloadHeaders(w, result.Header)
 	if _, err := io.Copy(w, result.Body); err != nil {
 		return fmt.Errorf("stream error: %w", err)
 	}
@@ -108,4 +114,24 @@ func (c *Client) BulkDeleteObjects(containerName string, names []string) error {
 		return err
 	}
 	return objects.BulkDelete(sc, containerName, names).Err
+}
+
+func copyDownloadHeaders(w io.Writer, headers http.Header) {
+	hw, ok := w.(responseHeaderWriter)
+	if !ok || headers == nil {
+		return
+	}
+
+	for _, name := range []string{
+		"Content-Type",
+		"Content-Length",
+		"Content-Disposition",
+		"Content-Encoding",
+		"ETag",
+		"Last-Modified",
+	} {
+		if value := headers.Get(name); value != "" {
+			hw.Header().Set(name, value)
+		}
+	}
 }

--- a/internal/domain/storage/client_test.go
+++ b/internal/domain/storage/client_test.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+func TestClientDownloadObjectPropagatesContentType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/test-container/index.html" {
+			t.Fatalf("expected path /test-container/index.html, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8; swift=stored")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<!doctype html><html></html>"))
+	}))
+	defer server.Close()
+
+	provider := &gophercloud.ProviderClient{
+		TokenID:    "token",
+		HTTPClient: *server.Client(),
+	}
+	provider.EndpointLocator = func(gophercloud.EndpointOpts) (string, error) {
+		return server.URL + "/", nil
+	}
+
+	client := NewClient(provider)
+	w := httptest.NewRecorder()
+
+	if err := client.DownloadObject("test-container", "index.html", w); err != nil {
+		t.Fatalf("DownloadObject: %v", err)
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/html; charset=utf-8; swift=stored" {
+		t.Fatalf("expected response content type text/html; charset=utf-8; swift=stored, got %q", got)
+	}
+	if got := w.Body.String(); got != "<!doctype html><html></html>" {
+		t.Fatalf("unexpected response body: %q", got)
+	}
+}

--- a/internal/domain/storage/content_type.go
+++ b/internal/domain/storage/content_type.go
@@ -1,0 +1,132 @@
+package storage
+
+import (
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/KHU-RETURN/rcp-server/internal/api"
+)
+
+const defaultObjectContentType = "application/octet-stream"
+
+var smartQuoteReplacer = strings.NewReplacer(
+	"\u2018", "",
+	"\u2019", "",
+	"\u201c", "",
+	"\u201d", "",
+)
+
+func resolveObjectContentType(file multipart.File, header *multipart.FileHeader, objectName string) string {
+	var rawContentType, filename string
+	if header != nil {
+		rawContentType = header.Header.Get(api.HeaderContentType)
+		filename = header.Filename
+	}
+
+	if contentType, ok := canonicalObjectContentType(rawContentType, false); ok {
+		return contentType
+	}
+	if contentType, ok := contentTypeFromName(objectName); ok {
+		return contentType
+	}
+	if contentType, ok := contentTypeFromName(filename); ok {
+		return contentType
+	}
+	if contentType, ok := sniffObjectContentType(file); ok {
+		if canonical, ok := canonicalObjectContentType(contentType, false); ok {
+			return canonical
+		}
+		if canonical, ok := canonicalObjectContentType(contentType, true); ok {
+			return canonical
+		}
+	}
+	if contentType, ok := canonicalObjectContentType(rawContentType, true); ok {
+		return contentType
+	}
+	return defaultObjectContentType
+}
+
+func canonicalObjectContentType(raw string, allowGeneric bool) (string, bool) {
+	raw = strings.TrimSpace(smartQuoteReplacer.Replace(raw))
+	if raw == "" {
+		return "", false
+	}
+
+	mediaType, params, err := mime.ParseMediaType(raw)
+	if err != nil || mediaType == "" {
+		return "", false
+	}
+
+	mediaType = strings.ToLower(mediaType)
+	if mediaType == defaultObjectContentType && !allowGeneric {
+		return "", false
+	}
+
+	normalizedParams := make(map[string]string, len(params))
+	for key, value := range params {
+		key = strings.ToLower(strings.TrimSpace(key))
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		if key == "charset" {
+			value = strings.Trim(value, `"`)
+			if strings.EqualFold(value, "utf8") {
+				value = "utf-8"
+			} else {
+				value = strings.ToLower(value)
+			}
+		}
+		normalizedParams[key] = value
+	}
+
+	if mediaType == "text/html" {
+		if _, ok := normalizedParams["charset"]; !ok {
+			normalizedParams["charset"] = "utf-8"
+		}
+	}
+
+	if contentType := mime.FormatMediaType(mediaType, normalizedParams); contentType != "" {
+		return contentType, true
+	}
+	return "", false
+}
+
+func contentTypeFromName(name string) (string, bool) {
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == "" {
+		return "", false
+	}
+	if ext == ".html" || ext == ".htm" {
+		return "text/html; charset=utf-8", true
+	}
+	return canonicalObjectContentType(mime.TypeByExtension(ext), false)
+}
+
+func sniffObjectContentType(file multipart.File) (string, bool) {
+	if file == nil {
+		return "", false
+	}
+
+	position, err := file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return "", false
+	}
+
+	buf := make([]byte, 512)
+	n, readErr := file.Read(buf)
+	if _, seekErr := file.Seek(position, io.SeekStart); seekErr != nil {
+		return "", false
+	}
+	if readErr != nil && readErr != io.EOF {
+		return "", false
+	}
+	if n == 0 {
+		return "", false
+	}
+	return http.DetectContentType(buf[:n]), true
+}

--- a/internal/domain/storage/handler.go
+++ b/internal/domain/storage/handler.go
@@ -139,7 +139,7 @@ func (h *Handler) UploadObject(c *gin.Context) {
 	}
 	defer func() { _ = file.Close() }()
 
-	contentType := header.Header.Get(api.HeaderContentType)
+	contentType := resolveObjectContentType(file, header, objectName)
 
 	if err := h.Svc.UploadObject(c.Request.Context(), id, containerName, objectName, file, contentType); err != nil {
 		switch {

--- a/internal/domain/storage/handler_test.go
+++ b/internal/domain/storage/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -182,13 +183,16 @@ func TestHandlerDeleteContainer(t *testing.T) {
 func TestHandlerUploadObject(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	makeMultipartRequest := func(t *testing.T, path, filename, content string) *http.Request {
+	makeMultipartRequestWithContentType := func(t *testing.T, path, filename, content, contentType string) *http.Request {
 		t.Helper()
 		body := &bytes.Buffer{}
 		writer := multipart.NewWriter(body)
-		fw, err := writer.CreateFormFile("file", filename)
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", multipart.FileContentDisposition("file", filename))
+		header.Set(api.HeaderContentType, contentType)
+		fw, err := writer.CreatePart(header)
 		if err != nil {
-			t.Fatalf("CreateFormFile: %v", err)
+			t.Fatalf("CreatePart: %v", err)
 		}
 		if _, err := io.WriteString(fw, content); err != nil {
 			t.Fatalf("WriteString: %v", err)
@@ -199,6 +203,10 @@ func TestHandlerUploadObject(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, path, body)
 		req.Header.Set(api.HeaderContentType, writer.FormDataContentType())
 		return req
+	}
+	makeMultipartRequest := func(t *testing.T, path, filename, content string) *http.Request {
+		t.Helper()
+		return makeMultipartRequestWithContentType(t, path, filename, content, "application/octet-stream")
 	}
 
 	t.Run("returns 201 with object key", func(t *testing.T) {
@@ -262,6 +270,76 @@ func TestHandlerUploadObject(t *testing.T) {
 		}
 		if res.Key != "dir/sub/a.txt" {
 			t.Fatalf("expected key dir/sub/a.txt, got %q", res.Key)
+		}
+	})
+
+	t.Run("detects html content type for generic multipart uploads", func(t *testing.T) {
+		const html = "<!doctype html><html><head><meta charset=\"utf-8\"></head><body>안녕하세요</body></html>"
+		var gotContentType string
+		var gotBody string
+		client := &fakeStorageClient{
+			uploadObjectFn: func(_, _ string, r io.Reader, contentType string) error {
+				gotContentType = contentType
+				body, err := io.ReadAll(r)
+				if err != nil {
+					t.Fatalf("ReadAll: %v", err)
+				}
+				gotBody = string(body)
+				return nil
+			},
+		}
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return &Container{Name: "my-bucket", OpenstackName: testContainerUUID}, nil
+			},
+		}
+
+		req := makeMultipartRequest(t, api.BasePath+"/storage/containers/my-bucket/objects/index.html", "index.html", html)
+		w := httptest.NewRecorder()
+		r := gin.New()
+		v1 := r.Group(api.BasePath)
+		withTestUser(v1)
+		newTestHandler(client, repo).InitRoutes(v1)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		if gotContentType != "text/html; charset=utf-8" {
+			t.Fatalf("expected content type text/html; charset=utf-8, got %q", gotContentType)
+		}
+		if gotBody != html {
+			t.Fatalf("uploaded body was not preserved: %q", gotBody)
+		}
+	})
+
+	t.Run("normalizes malformed utf8 charset content type", func(t *testing.T) {
+		var gotContentType string
+		client := &fakeStorageClient{
+			uploadObjectFn: func(_, _ string, _ io.Reader, contentType string) error {
+				gotContentType = contentType
+				return nil
+			},
+		}
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return &Container{Name: "my-bucket", OpenstackName: testContainerUUID}, nil
+			},
+		}
+
+		req := makeMultipartRequestWithContentType(t, api.BasePath+"/storage/containers/my-bucket/objects/index.html", "index.html", "<html></html>", "text/html; charset=utf-8\u201d")
+		w := httptest.NewRecorder()
+		r := gin.New()
+		v1 := r.Group(api.BasePath)
+		withTestUser(v1)
+		newTestHandler(client, repo).InitRoutes(v1)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		if gotContentType != "text/html; charset=utf-8" {
+			t.Fatalf("expected content type text/html; charset=utf-8, got %q", gotContentType)
 		}
 	})
 


### PR DESCRIPTION
## 변경 사항
  - 업로드 시 파일 파트의 Content-Type을 서버에서 정규화하도록 수정
  - `application/octet-stream` 또는 잘못된 charset 값이 들어온 경우 파일명/확장자/내용 기반으로 보정
  - HTML 오브젝트는 `text/html; charset=utf-8`로 저장되도록 처리
  - Swift 다운로드 응답의 Content-Type 등 주요 헤더를 클라이언트 응답에 전달
  - 업로드 Content-Type 정규화와 다운로드 헤더 전달 테스트 추가

  ## 검증
  - `gofmt -l $(git ls-files '*.go')`
  - `go mod tidy -diff`
  - `go generate ./cmd/api`
  - `go test ./...`
  - `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 run`
  - `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`