### PR TITLE
Chore/ci generated node24

### DIFF
--- a/.github/workflows/deploy-ns-proxy.yml
+++ b/.github/workflows/deploy-ns-proxy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Tailscale
         uses: tailscale/github-action@v2
@@ -23,7 +23,7 @@ jobs:
           authkey: ${{ secrets.TS_AUTHKEY }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
 
@@ -34,7 +34,7 @@ jobs:
         run: GOOS=linux GOARCH=amd64 go build -v -o ns-proxy ./cmd/ns-proxy
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ns-proxy-${{ github.sha }}
           path: ns-proxy

--- a/.github/workflows/deploy-ssh-gateway.yml
+++ b/.github/workflows/deploy-ssh-gateway.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Tailscale
         uses: tailscale/github-action@v2
@@ -28,7 +28,7 @@ jobs:
           authkey: ${{ secrets.TS_AUTHKEY }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Tailscale
         uses: tailscale/github-action@v2
@@ -17,7 +17,7 @@ jobs:
           authkey: ${{ secrets.TS_AUTHKEY }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
 
@@ -28,7 +28,7 @@ jobs:
         run: GOOS=linux GOARCH=amd64 go build -v -o server ./cmd/api/main.go
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rcp-server-${{ github.sha }}
           path: server

--- a/.github/workflows/go-pr-quality.yml
+++ b/.github/workflows/go-pr-quality.yml
@@ -31,7 +31,10 @@ jobs:
       - name: Regenerate Swagger docs
         run: go generate ./cmd/api
 
-      - name: Verify generated docs are committed
+      - name: Regenerate ent code
+        run: go run entc.go
+
+      - name: Verify generated artifacts are committed
         run: git diff --exit-code
 
   format:

--- a/GUIDELINE.md
+++ b/GUIDELINE.md
@@ -161,7 +161,7 @@ main.go → infrastructure 클라이언트 생성 → App 조립 → 라우터 �
 
 | 항목 | 사용 기술 |
 |------|-----------|
-| Language | Go 1.26.1 |
+| Language | Go 1.26.3 |
 | Web Framework | `gin-gonic/gin` |
 | OpenStack SDK | `gophercloud/gophercloud` |
 | Env Loader | `joho/godotenv` |

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ go run ./cmd/ssh-gateway  # 기본 127.0.0.1:2222 (cloudflared 뒤)
 
 API 기본 주소는 `http://localhost:8080`, SSH 게이트웨이는 `127.0.0.1:2222`(외부 직접 노출 X, cloudflared 터널 경유)입니다.
 
-## API Docs Generation
+## Generated Artifacts
 
 Swagger 문서는 Swaggo 주석 기반으로 생성합니다.
 
-문서를 갱신하려면:
+API 문서를 갱신하려면:
 
 ```bash
 go generate ./cmd/api
@@ -38,6 +38,14 @@ go generate ./cmd/api
 
 - `http://localhost:8080/docs`
 - `http://localhost:8080/openapi.yaml`
+
+ent schema 변경 후 ent client/migration 산출물을 갱신하려면:
+
+```bash
+go run entc.go
+```
+
+PR CI는 Swagger와 ent 산출물을 재생성한 뒤 `git diff --exit-code`로 커밋 누락을 검사합니다.
 
 ## SSH Access
 
@@ -66,15 +74,15 @@ ssh rcp-gw
 `main` 브랜치 머지 시 `compute-1` 호스트로 자동 배포됩니다.
 
 - `.github/workflows/deploy.yml` — rcp-server (매 머지마다)
-- `.github/workflows/deploy-ns-proxy.yml` — ns-proxy (`cmd/ns-proxy/**`나 `deploy/systemd/ns-proxy.service` 변경 시, 또는 `workflow_dispatch` 수동 trigger)
-- `.github/workflows/deploy-ssh-gateway.yml` — ssh-gateway (`cmd/ssh-gateway/**`나 SSH gateway systemd 변경 시)
+- `.github/workflows/deploy-ns-proxy.yml` — ns-proxy (`cmd/ns-proxy/**`, `internal/utils/**`, `deploy/systemd/ns-proxy.service`, workflow 변경 시, 또는 `workflow_dispatch` 수동 trigger)
+- `.github/workflows/deploy-ssh-gateway.yml` — ssh-gateway (`cmd/ssh-gateway/**`, SSH gateway 관련 access/database/openstack 코드, `internal/utils/**`, systemd example, workflow 변경 시, 또는 `workflow_dispatch` 수동 trigger)
 
 ### 기여할 때 알아둘 것
 
 - **새 환경변수 추가** — `cmd/api/main.go`의 `os.Getenv` + `deploy.yml`의 `envs:`/`printf` 블록 + GitHub Secrets, 세 군데를 같이 갱신해야 합니다
 - **systemd unit 변경** — `deploy/systemd/*.service`는 IaC로 관리됩니다. 머지하면 호스트의 `/etc/systemd/system/`에 자동 install + `daemon-reload` + `restart`가 일어나 즉시 운영에 반영됩니다
-- **ent schema 변경** — `NewEntClient`가 시작 시 `Schema.Create`를 자동 호출하므로 서버 재시작이 곧 마이그레이션입니다. prod DB와 호환되는 변경인지 확인 필요
-- **ns-proxy 의존 코드 변경** — `internal/` 등 공유 코드를 바꿨다면 ns-proxy 워크플로는 자동 trigger되지 않으니 GitHub Actions에서 `Run workflow`로 수동 실행
+- **ent schema 변경** — `go run entc.go`로 generated code를 갱신해야 합니다. 런타임에서는 `NewEntClient`가 시작 시 `Schema.Create`를 자동 호출하므로 서버 재시작이 곧 마이그레이션입니다. prod DB와 호환되는 변경인지 확인 필요
+- **ns-proxy 의존 코드 변경** — 자동 trigger path 밖의 공유 코드를 바꿨다면 ns-proxy 워크플로는 자동 trigger되지 않으니 GitHub Actions에서 `Run workflow`로 수동 실행
 - **OpenStack 라우터(qrouter) UUID 변경** — `RCP_NS_PROXY_ROUTER_ID` Secret 갱신 후 ns-proxy 워크플로 수동 재실행
 - **운영 로그 조회** — `ssh return@compute-1 journalctl -u rcp-server -f` (ns-proxy도 동일 패턴)
 - **로컬 개발** — 프로젝트 루트의 `.env`를 godotenv가 로드합니다. 운영에서는 systemd `EnvironmentFile`이 같은 역할을 하므로 동작이 일치합니다


### PR DESCRIPTION
## Summary

  - PR CI에서 `go run entc.go`를 실행해 ent generated/migration 산출물 미커밋을 잡도록 추가
  - GitHub Actions JS action runtime을 Node 24 기반 버전으로 업데이트
  - README/GUIDELINE 문서를 현재 CI, 배포 workflow, Go 버전에 맞게 정리

## Verification

  - `go generate ./cmd/api && go run entc.go && git diff --exit-code -- ent docs/generated go.mod go.sum`
  - `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml`
  - workflow action metadata 재조회로 `node20` 잔존 없음 확인