### PR TITLE
Fix/storage content type upload

### DIFF
--- a/internal/domain/storage/client.go
+++ b/internal/domain/storage/client.go
@@ -140,6 +140,10 @@ func copyDownloadHeaders(w io.Writer, headers http.Header, objectName string) {
 		}
 	}
 
+	if hw.Header().Get("Content-Type") == "" {
+		hw.Header().Set("Content-Type", defaultObjectContentType)
+	}
+	hw.Header().Set("X-Content-Type-Options", "nosniff")
 	if shouldForceAttachment(headers.Get("Content-Type"), objectName) {
 		hw.Header().Set("Content-Disposition", attachmentContentDisposition(objectName))
 	}

--- a/internal/domain/storage/client.go
+++ b/internal/domain/storage/client.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
@@ -14,6 +15,10 @@ import (
 
 type Client struct {
 	provider *gophercloud.ProviderClient
+}
+
+type responseHeaderWriter interface {
+	Header() http.Header
 }
 
 func NewClient(provider *gophercloud.ProviderClient) *Client {
@@ -88,6 +93,7 @@ func (c *Client) DownloadObject(containerName, objectName string, w io.Writer) e
 		return result.Err
 	}
 	defer func() { _ = result.Body.Close() }()
+	copyDownloadHeaders(w, result.Header)
 	if _, err := io.Copy(w, result.Body); err != nil {
 		return fmt.Errorf("stream error: %w", err)
 	}
@@ -108,4 +114,24 @@ func (c *Client) BulkDeleteObjects(containerName string, names []string) error {
 		return err
 	}
 	return objects.BulkDelete(sc, containerName, names).Err
+}
+
+func copyDownloadHeaders(w io.Writer, headers http.Header) {
+	hw, ok := w.(responseHeaderWriter)
+	if !ok || headers == nil {
+		return
+	}
+
+	for _, name := range []string{
+		"Content-Type",
+		"Content-Length",
+		"Content-Disposition",
+		"Content-Encoding",
+		"ETag",
+		"Last-Modified",
+	} {
+		if value := headers.Get(name); value != "" {
+			hw.Header().Set(name, value)
+		}
+	}
 }

--- a/internal/domain/storage/client.go
+++ b/internal/domain/storage/client.go
@@ -3,7 +3,10 @@ package storage
 import (
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
+	"path"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
@@ -93,7 +96,7 @@ func (c *Client) DownloadObject(containerName, objectName string, w io.Writer) e
 		return result.Err
 	}
 	defer func() { _ = result.Body.Close() }()
-	copyDownloadHeaders(w, result.Header)
+	copyDownloadHeaders(w, result.Header, objectName)
 	if _, err := io.Copy(w, result.Body); err != nil {
 		return fmt.Errorf("stream error: %w", err)
 	}
@@ -116,22 +119,67 @@ func (c *Client) BulkDeleteObjects(containerName string, names []string) error {
 	return objects.BulkDelete(sc, containerName, names).Err
 }
 
-func copyDownloadHeaders(w io.Writer, headers http.Header) {
+func copyDownloadHeaders(w io.Writer, headers http.Header, objectName string) {
 	hw, ok := w.(responseHeaderWriter)
-	if !ok || headers == nil {
+	if !ok {
 		return
 	}
 
-	for _, name := range []string{
-		"Content-Type",
-		"Content-Length",
-		"Content-Disposition",
-		"Content-Encoding",
-		"ETag",
-		"Last-Modified",
-	} {
-		if value := headers.Get(name); value != "" {
-			hw.Header().Set(name, value)
+	if headers != nil {
+		for _, name := range []string{
+			"Content-Type",
+			"Content-Length",
+			"Content-Disposition",
+			"Content-Encoding",
+			"ETag",
+			"Last-Modified",
+		} {
+			if value := headers.Get(name); value != "" {
+				hw.Header().Set(name, value)
+			}
 		}
 	}
+
+	if shouldForceAttachment(headers.Get("Content-Type"), objectName) {
+		hw.Header().Set("Content-Disposition", attachmentContentDisposition(objectName))
+	}
+}
+
+func shouldForceAttachment(contentType, objectName string) bool {
+	if isActiveContentType(contentType) {
+		return true
+	}
+
+	switch strings.ToLower(path.Ext(objectName)) {
+	case ".html", ".htm", ".svg":
+		return true
+	default:
+		return false
+	}
+}
+
+func isActiveContentType(contentType string) bool {
+	contentType = strings.TrimSpace(smartQuoteReplacer.Replace(contentType))
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType, _, _ = strings.Cut(contentType, ";")
+	}
+
+	switch strings.ToLower(strings.TrimSpace(mediaType)) {
+	case "text/html", "application/xhtml+xml", "image/svg+xml":
+		return true
+	default:
+		return false
+	}
+}
+
+func attachmentContentDisposition(objectName string) string {
+	filename := path.Base(strings.TrimSpace(objectName))
+	if filename == "" || filename == "." || filename == "/" {
+		filename = "download"
+	}
+	if value := mime.FormatMediaType("attachment", map[string]string{"filename": filename}); value != "" {
+		return value
+	}
+	return "attachment"
 }

--- a/internal/domain/storage/client_test.go
+++ b/internal/domain/storage/client_test.go
@@ -14,38 +14,30 @@ func TestClientDownloadObjectPropagatesResponseHeaders(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Fatalf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/test-container/index.html" {
-			t.Fatalf("expected path /test-container/index.html, got %s", r.URL.Path)
+		if r.URL.Path != "/test-container/readme.txt" {
+			t.Fatalf("expected path /test-container/readme.txt, got %s", r.URL.Path)
 		}
 
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Header().Set("Content-Length", "28")
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("Content-Length", "11")
 		w.Header().Set("ETag", `"abc123"`)
 		w.Header().Set("Last-Modified", "Mon, 01 Jun 2026 00:00:00 GMT")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("<!doctype html><html></html>"))
+		_, _ = w.Write([]byte("hello world"))
 	}))
 	defer server.Close()
 
-	provider := &gophercloud.ProviderClient{
-		TokenID:    "token",
-		HTTPClient: *server.Client(),
-	}
-	provider.EndpointLocator = func(gophercloud.EndpointOpts) (string, error) {
-		return server.URL + "/", nil
-	}
-
-	client := NewClient(provider)
+	client := newTestObjectStorageClient(server)
 	w := httptest.NewRecorder()
 
-	if err := client.DownloadObject("test-container", "index.html", w); err != nil {
+	if err := client.DownloadObject("test-container", "readme.txt", w); err != nil {
 		t.Fatalf("DownloadObject: %v", err)
 	}
-	if got := w.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
-		t.Fatalf("expected response content type text/html; charset=utf-8, got %q", got)
+	if got := w.Header().Get("Content-Type"); got != "text/plain; charset=utf-8" {
+		t.Fatalf("expected response content type text/plain; charset=utf-8, got %q", got)
 	}
-	if got := w.Header().Get("Content-Length"); got != "28" {
-		t.Fatalf("expected response content length 28, got %q", got)
+	if got := w.Header().Get("Content-Length"); got != "11" {
+		t.Fatalf("expected response content length 11, got %q", got)
 	}
 	if got := w.Header().Get("ETag"); got != `"abc123"` {
 		t.Fatalf("expected response etag, got %q", got)
@@ -53,7 +45,10 @@ func TestClientDownloadObjectPropagatesResponseHeaders(t *testing.T) {
 	if got := w.Header().Get("Last-Modified"); got != "Mon, 01 Jun 2026 00:00:00 GMT" {
 		t.Fatalf("expected response last modified, got %q", got)
 	}
-	if got := w.Body.String(); got != "<!doctype html><html></html>" {
+	if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("expected nosniff header, got %q", got)
+	}
+	if got := w.Body.String(); got != "hello world" {
 		t.Fatalf("unexpected response body: %q", got)
 	}
 }
@@ -149,6 +144,20 @@ func TestClientDownloadObjectPreservesPassiveContentDisposition(t *testing.T) {
 	}
 	if got := w.Header().Get("Content-Disposition"); got != `inline; filename="photo.png"` {
 		t.Fatalf("expected passive content disposition to be preserved, got %q", got)
+	}
+}
+
+func TestClientDownloadObjectDefaultsMissingContentType(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	copyDownloadHeaders(w, http.Header{}, "legacy.bin")
+	_, _ = w.Write([]byte("<!doctype html><html></html>"))
+
+	if got := w.Header().Get("Content-Type"); got != "application/octet-stream" {
+		t.Fatalf("expected default content type application/octet-stream, got %q", got)
+	}
+	if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("expected nosniff header, got %q", got)
 	}
 }
 

--- a/internal/domain/storage/client_test.go
+++ b/internal/domain/storage/client_test.go
@@ -1,0 +1,58 @@
+package storage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+func TestClientDownloadObjectPropagatesResponseHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/test-container/index.html" {
+			t.Fatalf("expected path /test-container/index.html, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Content-Length", "28")
+		w.Header().Set("ETag", `"abc123"`)
+		w.Header().Set("Last-Modified", "Mon, 01 Jun 2026 00:00:00 GMT")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<!doctype html><html></html>"))
+	}))
+	defer server.Close()
+
+	provider := &gophercloud.ProviderClient{
+		TokenID:    "token",
+		HTTPClient: *server.Client(),
+	}
+	provider.EndpointLocator = func(gophercloud.EndpointOpts) (string, error) {
+		return server.URL + "/", nil
+	}
+
+	client := NewClient(provider)
+	w := httptest.NewRecorder()
+
+	if err := client.DownloadObject("test-container", "index.html", w); err != nil {
+		t.Fatalf("DownloadObject: %v", err)
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Fatalf("expected response content type text/html; charset=utf-8, got %q", got)
+	}
+	if got := w.Header().Get("Content-Length"); got != "28" {
+		t.Fatalf("expected response content length 28, got %q", got)
+	}
+	if got := w.Header().Get("ETag"); got != `"abc123"` {
+		t.Fatalf("expected response etag, got %q", got)
+	}
+	if got := w.Header().Get("Last-Modified"); got != "Mon, 01 Jun 2026 00:00:00 GMT" {
+		t.Fatalf("expected response last modified, got %q", got)
+	}
+	if got := w.Body.String(); got != "<!doctype html><html></html>" {
+		t.Fatalf("unexpected response body: %q", got)
+	}
+}

--- a/internal/domain/storage/client_test.go
+++ b/internal/domain/storage/client_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"mime"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -55,4 +56,109 @@ func TestClientDownloadObjectPropagatesResponseHeaders(t *testing.T) {
 	if got := w.Body.String(); got != "<!doctype html><html></html>" {
 		t.Fatalf("unexpected response body: %q", got)
 	}
+}
+
+func TestClientDownloadObjectForcesAttachmentForActiveContent(t *testing.T) {
+	tests := []struct {
+		name               string
+		objectName         string
+		contentType        string
+		contentDisposition string
+		wantFilename       string
+	}{
+		{
+			name:         "html content type",
+			objectName:   "index.html",
+			contentType:  "text/html; charset=utf-8",
+			wantFilename: "index.html",
+		},
+		{
+			name:         "html extension",
+			objectName:   "page.htm",
+			contentType:  "application/octet-stream",
+			wantFilename: "page.htm",
+		},
+		{
+			name:               "svg overrides inline disposition",
+			objectName:         "icon.svg",
+			contentType:        "image/svg+xml",
+			contentDisposition: `inline; filename="icon.svg"`,
+			wantFilename:       "icon.svg",
+		},
+		{
+			name:         "xhtml content type",
+			objectName:   "document.bin",
+			contentType:  "application/xhtml+xml",
+			wantFilename: "document.bin",
+		},
+		{
+			name:         "malformed html content type",
+			objectName:   "legacy.txt",
+			contentType:  "text/html; charset=utf-8\u201d",
+			wantFilename: "legacy.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", tt.contentType)
+				if tt.contentDisposition != "" {
+					w.Header().Set("Content-Disposition", tt.contentDisposition)
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("body"))
+			}))
+			defer server.Close()
+
+			client := newTestObjectStorageClient(server)
+			w := httptest.NewRecorder()
+
+			if err := client.DownloadObject("test-container", tt.objectName, w); err != nil {
+				t.Fatalf("DownloadObject: %v", err)
+			}
+
+			disposition, params, err := mime.ParseMediaType(w.Header().Get("Content-Disposition"))
+			if err != nil {
+				t.Fatalf("ParseMediaType: %v", err)
+			}
+			if disposition != "attachment" {
+				t.Fatalf("expected attachment disposition, got %q", disposition)
+			}
+			if params["filename"] != tt.wantFilename {
+				t.Fatalf("expected filename %q, got %q", tt.wantFilename, params["filename"])
+			}
+		})
+	}
+}
+
+func TestClientDownloadObjectPreservesPassiveContentDisposition(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("Content-Disposition", `inline; filename="photo.png"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("png"))
+	}))
+	defer server.Close()
+
+	client := newTestObjectStorageClient(server)
+	w := httptest.NewRecorder()
+
+	if err := client.DownloadObject("test-container", "photo.png", w); err != nil {
+		t.Fatalf("DownloadObject: %v", err)
+	}
+	if got := w.Header().Get("Content-Disposition"); got != `inline; filename="photo.png"` {
+		t.Fatalf("expected passive content disposition to be preserved, got %q", got)
+	}
+}
+
+func newTestObjectStorageClient(server *httptest.Server) *Client {
+	provider := &gophercloud.ProviderClient{
+		TokenID:    "token",
+		HTTPClient: *server.Client(),
+	}
+	provider.EndpointLocator = func(gophercloud.EndpointOpts) (string, error) {
+		return server.URL + "/", nil
+	}
+	return NewClient(provider)
 }

--- a/internal/domain/storage/content_type.go
+++ b/internal/domain/storage/content_type.go
@@ -1,14 +1,12 @@
 package storage
 
 import (
+	"bytes"
 	"io"
 	"mime"
-	"mime/multipart"
 	"net/http"
 	"path/filepath"
 	"strings"
-
-	"github.com/KHU-RETURN/rcp-server/internal/api"
 )
 
 const defaultObjectContentType = "application/octet-stream"
@@ -20,34 +18,30 @@ var smartQuoteReplacer = strings.NewReplacer(
 	"\u201d", "",
 )
 
-func resolveObjectContentType(file multipart.File, header *multipart.FileHeader, objectName string) string {
-	var rawContentType, filename string
-	if header != nil {
-		rawContentType = header.Header.Get(api.HeaderContentType)
-		filename = header.Filename
-	}
-
+func resolveObjectContentStream(r io.Reader, rawContentType, filename, objectName string) (io.Reader, string) {
 	if contentType, ok := canonicalObjectContentType(rawContentType, false); ok {
-		return contentType
+		return r, contentType
 	}
 	if contentType, ok := contentTypeFromName(objectName); ok {
-		return contentType
+		return r, contentType
 	}
 	if contentType, ok := contentTypeFromName(filename); ok {
-		return contentType
+		return r, contentType
 	}
-	if contentType, ok := sniffObjectContentType(file); ok {
-		if canonical, ok := canonicalObjectContentType(contentType, false); ok {
-			return canonical
+
+	r, sniffedContentType, sniffed := sniffObjectContentType(r)
+	if sniffed {
+		if canonical, ok := canonicalObjectContentType(sniffedContentType, false); ok {
+			return r, canonical
 		}
-		if canonical, ok := canonicalObjectContentType(contentType, true); ok {
-			return canonical
+		if canonical, ok := canonicalObjectContentType(sniffedContentType, true); ok {
+			return r, canonical
 		}
 	}
 	if contentType, ok := canonicalObjectContentType(rawContentType, true); ok {
-		return contentType
+		return r, contentType
 	}
-	return defaultObjectContentType
+	return r, defaultObjectContentType
 }
 
 func canonicalObjectContentType(raw string, allowGeneric bool) (string, bool) {
@@ -107,26 +101,18 @@ func contentTypeFromName(name string) (string, bool) {
 	return canonicalObjectContentType(mime.TypeByExtension(ext), false)
 }
 
-func sniffObjectContentType(file multipart.File) (string, bool) {
-	if file == nil {
-		return "", false
-	}
-
-	position, err := file.Seek(0, io.SeekCurrent)
-	if err != nil {
-		return "", false
+func sniffObjectContentType(r io.Reader) (io.Reader, string, bool) {
+	if r == nil {
+		return r, "", false
 	}
 
 	buf := make([]byte, 512)
-	n, readErr := file.Read(buf)
-	if _, seekErr := file.Seek(position, io.SeekStart); seekErr != nil {
-		return "", false
-	}
-	if readErr != nil && readErr != io.EOF {
-		return "", false
+	n, err := r.Read(buf)
+	if err != nil && err != io.EOF {
+		return io.MultiReader(bytes.NewReader(buf[:n]), r), "", false
 	}
 	if n == 0 {
-		return "", false
+		return r, "", false
 	}
-	return http.DetectContentType(buf[:n]), true
+	return io.MultiReader(bytes.NewReader(buf[:n]), r), http.DetectContentType(buf[:n]), true
 }

--- a/internal/domain/storage/content_type.go
+++ b/internal/domain/storage/content_type.go
@@ -1,0 +1,132 @@
+package storage
+
+import (
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/KHU-RETURN/rcp-server/internal/api"
+)
+
+const defaultObjectContentType = "application/octet-stream"
+
+var smartQuoteReplacer = strings.NewReplacer(
+	"\u2018", "",
+	"\u2019", "",
+	"\u201c", "",
+	"\u201d", "",
+)
+
+func resolveObjectContentType(file multipart.File, header *multipart.FileHeader, objectName string) string {
+	var rawContentType, filename string
+	if header != nil {
+		rawContentType = header.Header.Get(api.HeaderContentType)
+		filename = header.Filename
+	}
+
+	if contentType, ok := canonicalObjectContentType(rawContentType, false); ok {
+		return contentType
+	}
+	if contentType, ok := contentTypeFromName(objectName); ok {
+		return contentType
+	}
+	if contentType, ok := contentTypeFromName(filename); ok {
+		return contentType
+	}
+	if contentType, ok := sniffObjectContentType(file); ok {
+		if canonical, ok := canonicalObjectContentType(contentType, false); ok {
+			return canonical
+		}
+		if canonical, ok := canonicalObjectContentType(contentType, true); ok {
+			return canonical
+		}
+	}
+	if contentType, ok := canonicalObjectContentType(rawContentType, true); ok {
+		return contentType
+	}
+	return defaultObjectContentType
+}
+
+func canonicalObjectContentType(raw string, allowGeneric bool) (string, bool) {
+	raw = strings.TrimSpace(smartQuoteReplacer.Replace(raw))
+	if raw == "" {
+		return "", false
+	}
+
+	mediaType, params, err := mime.ParseMediaType(raw)
+	if err != nil || mediaType == "" {
+		return "", false
+	}
+
+	mediaType = strings.ToLower(mediaType)
+	if mediaType == defaultObjectContentType && !allowGeneric {
+		return "", false
+	}
+
+	normalizedParams := make(map[string]string, len(params))
+	for key, value := range params {
+		key = strings.ToLower(strings.TrimSpace(key))
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		if key == "charset" {
+			value = strings.Trim(value, `"`)
+			if strings.EqualFold(value, "utf8") {
+				value = "utf-8"
+			} else {
+				value = strings.ToLower(value)
+			}
+		}
+		normalizedParams[key] = value
+	}
+
+	if mediaType == "text/html" {
+		if _, ok := normalizedParams["charset"]; !ok {
+			normalizedParams["charset"] = "utf-8"
+		}
+	}
+
+	if contentType := mime.FormatMediaType(mediaType, normalizedParams); contentType != "" {
+		return contentType, true
+	}
+	return "", false
+}
+
+func contentTypeFromName(name string) (string, bool) {
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == "" {
+		return "", false
+	}
+	if ext == ".html" || ext == ".htm" {
+		return "text/html; charset=utf-8", true
+	}
+	return canonicalObjectContentType(mime.TypeByExtension(ext), false)
+}
+
+func sniffObjectContentType(file multipart.File) (string, bool) {
+	if file == nil {
+		return "", false
+	}
+
+	position, err := file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return "", false
+	}
+
+	buf := make([]byte, 512)
+	n, readErr := file.Read(buf)
+	if _, seekErr := file.Seek(position, io.SeekStart); seekErr != nil {
+		return "", false
+	}
+	if readErr != nil && readErr != io.EOF {
+		return "", false
+	}
+	if n == 0 {
+		return "", false
+	}
+	return http.DetectContentType(buf[:n]), true
+}

--- a/internal/domain/storage/content_type_test.go
+++ b/internal/domain/storage/content_type_test.go
@@ -1,0 +1,66 @@
+package storage
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestResolveObjectContentStreamSniffsOneChunkAndPreservesBody(t *testing.T) {
+	source := &chunkedReader{
+		chunks: []string{"<!doctype html>", "<html><body>hello</body></html>"},
+	}
+
+	stream, contentType := resolveObjectContentStream(source, "application/octet-stream", "", "")
+	if contentType != "text/html; charset=utf-8" {
+		t.Fatalf("expected text/html; charset=utf-8, got %q", contentType)
+	}
+	if source.reads != 1 {
+		t.Fatalf("expected content type sniffing to read one chunk, got %d reads", source.reads)
+	}
+
+	body, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if body := string(body); body != "<!doctype html><html><body>hello</body></html>" {
+		t.Fatalf("stream body was not preserved: %q", body)
+	}
+}
+
+type chunkedReader struct {
+	chunks []string
+	reads  int
+}
+
+func (r *chunkedReader) Read(p []byte) (int, error) {
+	if r.reads >= len(r.chunks) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.chunks[r.reads])
+	r.chunks[r.reads] = r.chunks[r.reads][n:]
+	if r.chunks[r.reads] == "" {
+		r.reads++
+	}
+	return n, nil
+}
+
+func TestCanonicalObjectContentTypeStripsSmartQuotes(t *testing.T) {
+	contentType, ok := canonicalObjectContentType("text/html; charset=utf-8\u201d", false)
+	if !ok {
+		t.Fatal("expected content type to normalize")
+	}
+	if contentType != "text/html; charset=utf-8" {
+		t.Fatalf("expected text/html; charset=utf-8, got %q", contentType)
+	}
+}
+
+func TestContentTypeFromHTMLNameAddsUTF8Charset(t *testing.T) {
+	contentType, ok := contentTypeFromName(strings.ToUpper("INDEX.HTML"))
+	if !ok {
+		t.Fatal("expected html extension to resolve")
+	}
+	if contentType != "text/html; charset=utf-8" {
+		t.Fatalf("expected text/html; charset=utf-8, got %q", contentType)
+	}
+}

--- a/internal/domain/storage/handler.go
+++ b/internal/domain/storage/handler.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -134,25 +135,49 @@ func (h *Handler) UploadObject(c *gin.Context) {
 		return
 	}
 
-	file, header, err := c.Request.FormFile("file")
+	reader, err := c.Request.MultipartReader()
 	if err != nil {
 		c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "missing file"})
 		return
 	}
-	defer func() { _ = file.Close() }()
 
-	contentType := resolveObjectContentType(file, header, objectName)
-
-	if err := h.Svc.UploadObject(c.Request.Context(), id, containerName, objectName, file, contentType); err != nil {
-		switch {
-		case errors.Is(err, ErrContainerNotFound):
-			c.JSON(http.StatusNotFound, api.ErrorResponse{Error: err.Error()})
-		default:
-			c.JSON(http.StatusInternalServerError, api.ErrorResponse{Error: err.Error()})
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
 		}
+		if err != nil {
+			c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "invalid multipart body"})
+			return
+		}
+		if part.FormName() != "file" {
+			_ = part.Close()
+			continue
+		}
+
+		fileStream, contentType := resolveObjectContentStream(
+			part,
+			part.Header.Get(api.HeaderContentType),
+			part.FileName(),
+			objectName,
+		)
+
+		if err := h.Svc.UploadObject(c.Request.Context(), id, containerName, objectName, fileStream, contentType); err != nil {
+			_ = part.Close()
+			switch {
+			case errors.Is(err, ErrContainerNotFound):
+				c.JSON(http.StatusNotFound, api.ErrorResponse{Error: err.Error()})
+			default:
+				c.JSON(http.StatusInternalServerError, api.ErrorResponse{Error: err.Error()})
+			}
+			return
+		}
+		_ = part.Close()
+		c.JSON(http.StatusCreated, UploadObjectResponse{Key: objectName})
 		return
 	}
-	c.JSON(http.StatusCreated, UploadObjectResponse{Key: objectName})
+
+	c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "missing file"})
 }
 
 func (h *Handler) DownloadObject(c *gin.Context) {

--- a/internal/domain/storage/handler.go
+++ b/internal/domain/storage/handler.go
@@ -141,7 +141,7 @@ func (h *Handler) UploadObject(c *gin.Context) {
 	}
 	defer func() { _ = file.Close() }()
 
-	contentType := header.Header.Get(api.HeaderContentType)
+	contentType := resolveObjectContentType(file, header, objectName)
 
 	if err := h.Svc.UploadObject(c.Request.Context(), id, containerName, objectName, file, contentType); err != nil {
 		switch {

--- a/internal/domain/storage/handler_test.go
+++ b/internal/domain/storage/handler_test.go
@@ -5,12 +5,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/textproto"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -355,6 +358,89 @@ func TestHandlerUploadObject(t *testing.T) {
 		}
 		if gotContentType != "text/html; charset=utf-8" {
 			t.Fatalf("expected content type text/html; charset=utf-8, got %q", gotContentType)
+		}
+	})
+
+	t.Run("streams multipart file part before request body is fully read", func(t *testing.T) {
+		uploadStarted := make(chan struct{})
+		writeErr := make(chan error, 1)
+		bodyReader, bodyWriter := io.Pipe()
+		writer := multipart.NewWriter(bodyWriter)
+		content := "<!doctype html>" + strings.Repeat("a", 1024)
+
+		client := &fakeStorageClient{
+			uploadObjectFn: func(_, _ string, r io.Reader, contentType string) error {
+				buf := make([]byte, len("<!doctype html>"))
+				if _, err := io.ReadFull(r, buf); err != nil {
+					return err
+				}
+				if string(buf) != "<!doctype html>" {
+					return errors.New("upload stream did not start with file content")
+				}
+				if contentType != "text/html; charset=utf-8" {
+					return errors.New("upload stream had unexpected content type")
+				}
+				close(uploadStarted)
+				_, err := io.Copy(io.Discard, r)
+				return err
+			},
+		}
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return &Container{Name: "my-bucket", OpenstackName: testContainerUUID}, nil
+			},
+		}
+
+		go func() {
+			header := make(textproto.MIMEHeader)
+			header.Set("Content-Disposition", multipart.FileContentDisposition("file", "index.html"))
+			header.Set(api.HeaderContentType, "application/octet-stream")
+			fw, err := writer.CreatePart(header)
+			if err != nil {
+				_ = bodyWriter.CloseWithError(err)
+				writeErr <- err
+				return
+			}
+			if _, err := io.WriteString(fw, content); err != nil {
+				_ = bodyWriter.CloseWithError(err)
+				writeErr <- err
+				return
+			}
+			select {
+			case <-uploadStarted:
+			case <-time.After(2 * time.Second):
+				err := errors.New("upload did not start before multipart body was closed")
+				_ = writer.Close()
+				_ = bodyWriter.CloseWithError(err)
+				writeErr <- err
+				return
+			}
+			if err := writer.Close(); err != nil {
+				_ = bodyWriter.CloseWithError(err)
+				writeErr <- err
+				return
+			}
+			if err := bodyWriter.Close(); err != nil {
+				writeErr <- err
+				return
+			}
+			writeErr <- nil
+		}()
+
+		req := httptest.NewRequest(http.MethodPost, api.BasePath+"/storage/containers/my-bucket/objects/index.html", bodyReader)
+		req.Header.Set(api.HeaderContentType, writer.FormDataContentType())
+		w := httptest.NewRecorder()
+		r := gin.New()
+		v1 := r.Group(api.BasePath)
+		withTestUser(v1)
+		newTestHandler(client, repo).InitRoutes(v1)
+		r.ServeHTTP(w, req)
+
+		if err := <-writeErr; err != nil {
+			t.Fatal(err)
+		}
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
 		}
 	})
 

--- a/internal/domain/storage/handler_test.go
+++ b/internal/domain/storage/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -201,6 +202,27 @@ func TestHandlerUploadObject(t *testing.T) {
 		req.Header.Set(api.HeaderContentType, writer.FormDataContentType())
 		return req
 	}
+	makeMultipartRequestWithContentType := func(t *testing.T, path, filename, content, contentType string) *http.Request {
+		t.Helper()
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", multipart.FileContentDisposition("file", filename))
+		header.Set(api.HeaderContentType, contentType)
+		fw, err := writer.CreatePart(header)
+		if err != nil {
+			t.Fatalf("CreatePart: %v", err)
+		}
+		if _, err := io.WriteString(fw, content); err != nil {
+			t.Fatalf("WriteString: %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("writer.Close: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, path, body)
+		req.Header.Set(api.HeaderContentType, writer.FormDataContentType())
+		return req
+	}
 
 	t.Run("returns 201 with object key", func(t *testing.T) {
 		repo := &fakeContainerRepo{
@@ -263,6 +285,76 @@ func TestHandlerUploadObject(t *testing.T) {
 		}
 		if res.Key != "dir/sub/a.txt" {
 			t.Fatalf("expected key dir/sub/a.txt, got %q", res.Key)
+		}
+	})
+
+	t.Run("normalizes html content type for generic multipart uploads", func(t *testing.T) {
+		const html = "<!doctype html><html><head><meta charset=\"utf-8\"></head><body>hello</body></html>"
+		var gotContentType string
+		var gotBody string
+		client := &fakeStorageClient{
+			uploadObjectFn: func(_, _ string, r io.Reader, contentType string) error {
+				gotContentType = contentType
+				body, err := io.ReadAll(r)
+				if err != nil {
+					t.Fatalf("ReadAll: %v", err)
+				}
+				gotBody = string(body)
+				return nil
+			},
+		}
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return &Container{Name: "my-bucket", OpenstackName: testContainerUUID}, nil
+			},
+		}
+
+		req := makeMultipartRequest(t, api.BasePath+"/storage/containers/my-bucket/objects/index.html", "index.html", html)
+		w := httptest.NewRecorder()
+		r := gin.New()
+		v1 := r.Group(api.BasePath)
+		withTestUser(v1)
+		newTestHandler(client, repo).InitRoutes(v1)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		if gotContentType != "text/html; charset=utf-8" {
+			t.Fatalf("expected content type text/html; charset=utf-8, got %q", gotContentType)
+		}
+		if gotBody != html {
+			t.Fatalf("uploaded body was not preserved: %q", gotBody)
+		}
+	})
+
+	t.Run("normalizes malformed utf8 charset content type", func(t *testing.T) {
+		var gotContentType string
+		client := &fakeStorageClient{
+			uploadObjectFn: func(_, _ string, _ io.Reader, contentType string) error {
+				gotContentType = contentType
+				return nil
+			},
+		}
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return &Container{Name: "my-bucket", OpenstackName: testContainerUUID}, nil
+			},
+		}
+
+		req := makeMultipartRequestWithContentType(t, api.BasePath+"/storage/containers/my-bucket/objects/index.html", "index.html", "<html></html>", "text/html; charset=utf-8\u201d")
+		w := httptest.NewRecorder()
+		r := gin.New()
+		v1 := r.Group(api.BasePath)
+		withTestUser(v1)
+		newTestHandler(client, repo).InitRoutes(v1)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		if gotContentType != "text/html; charset=utf-8" {
+			t.Fatalf("expected content type text/html; charset=utf-8, got %q", gotContentType)
 		}
 	})
 


### PR DESCRIPTION
## 요약
  - 업로드된 object의 `Content-Type`을 정규화했습니다.
    - `charset=utf8`
    - `charset=utf-8”` 같은 smart quote 포함 케이스
    - `.html`, `.htm` 확장자 기반 HTML 타입 보정
  - multipart object 업로드를 전체 파일 버퍼링 없이 스트리밍 방식으로 변경했습니다.
  - object 다운로드도 Swift 응답 body를 스트리밍으로 전달하도록 유지했습니다.
  - Swift의 다운로드 응답 헤더를 클라이언트에 전달하되, active content 렌더링 위험을 막았습니다.
  - HTML/XHTML/SVG 다운로드는 `Content-Disposition: attachment`를 강제했습니다.
  - 다운로드 응답에 `X-Content-Type-Options: nosniff`를 추가했습니다.
  - Swift에서 `Content-Type`이 누락된 경우 `application/octet-stream`을 기본값으로 설정했습니다.

  ## 검증
  - `go test ./...`
  - `go vet ./...`
  - `go run honnef.co/go/tools/cmd/staticcheck@latest ./internal/domain/storage`
  - `git diff --check`

  ## 참고
  - 인증 쿠키가 붙는 API origin에서 사용자 업로드 HTML/SVG가 inline 렌더링되지 않도록 서버에서 방어했습니다.
  - 미리보기나 정적 호스팅이 필요하면 쿠키가 없는 별도 object-serving origin을 사용하는 방향이 안전합니다.