### PR TITLE
fix(db): revert default DSN to relative path

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -108,7 +108,7 @@ func resolveDBConfig(getenv func(string) string) (string, string) {
 	}
 	dsn := strings.TrimSpace(getenv("DB_DSN"))
 	if dsn == "" {
-		dsn = "file:/var/lib/rcp/rcp.db?cache=shared&_pragma=foreign_keys(1)"
+		dsn = "file:rcp.db?cache=shared&_pragma=foreign_keys(1)"
 	}
 	return driver, dsn
 }

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -35,7 +35,7 @@ func TestResolveDBDSNDefaultsToCanonicalSQLitePath(t *testing.T) {
 	if driver != "sqlite3" {
 		t.Fatalf("driver got %q", driver)
 	}
-	if dsn != "file:/var/lib/rcp/rcp.db?cache=shared&_pragma=foreign_keys(1)" {
+	if dsn != "file:rcp.db?cache=shared&_pragma=foreign_keys(1)" {
 		t.Fatalf("dsn got %q", dsn)
 	}
 }


### PR DESCRIPTION
Restore the pre-PR default of file:rcp.db so the binary still works without DB_DSN in local/dev environments. Operational deployments should set DB_DSN explicitly via secrets.