### PR TITLE
fix(access): validate VM host keys through ns-proxy

### DIFF
--- a/cmd/ssh-gateway/hostkey_test.go
+++ b/cmd/ssh-gateway/hostkey_test.go
@@ -45,6 +45,28 @@ func TestLoadInnerHostKeyCallbackAcceptsKnownHost(t *testing.T) {
 	}
 }
 
+func TestInnerHostKeyCallbackForAddressIgnoresProxyRemoteAddr(t *testing.T) {
+	hostKeyPath := filepath.Join(t.TempDir(), "host_ed25519")
+	signer, err := LoadOrCreateHostKey(hostKeyPath)
+	if err != nil {
+		t.Fatalf("host key: %v", err)
+	}
+	knownHostsPath := filepath.Join(t.TempDir(), "known_hosts")
+	line := knownhosts.Line([]string{"10.0.0.7"}, signer.PublicKey())
+	if err := os.WriteFile(knownHostsPath, []byte(line+"\n"), 0o600); err != nil {
+		t.Fatalf("write known_hosts: %v", err)
+	}
+
+	cb, err := loadInnerHostKeyCallback(knownHostsPath)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	wrapped := innerHostKeyCallbackForAddress("10.0.0.7:22", cb)
+	if err := wrapped("", &net.UnixAddr{Name: "/run/rcp/ns-proxy.sock", Net: "unix"}, signer.PublicKey()); err != nil {
+		t.Fatalf("known host rejected through proxy remote addr: %v", err)
+	}
+}
+
 func TestReloadingInnerHostKeyCallbackPicksUpCreatedFile(t *testing.T) {
 	hostKeyPath := filepath.Join(t.TempDir(), "host_ed25519")
 	signer, err := LoadOrCreateHostKey(hostKeyPath)

--- a/cmd/ssh-gateway/relay.go
+++ b/cmd/ssh-gateway/relay.go
@@ -94,7 +94,7 @@ func dialInnerSSH(ctx context.Context, raw net.Conn, addr, user string, ag agent
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeysCallback(ag.Signers),
 		},
-		HostKeyCallback: hostKeyCallback,
+		HostKeyCallback: innerHostKeyCallbackForAddress(addr, hostKeyCallback),
 		Timeout:         15 * time.Second,
 	}
 	if dl, ok := ctx.Deadline(); ok {
@@ -106,6 +106,20 @@ func dialInnerSSH(ctx context.Context, raw net.Conn, addr, user string, ag agent
 		return nil, fmt.Errorf("inner ssh handshake: %w", err)
 	}
 	return ssh.NewClient(c, chans, reqs), nil
+}
+
+func innerHostKeyCallbackForAddress(address string, cb ssh.HostKeyCallback) ssh.HostKeyCallback {
+	return func(_ string, _ net.Addr, key ssh.PublicKey) error {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return err
+		}
+		portNumber, err := strconv.Atoi(port)
+		if err != nil {
+			return err
+		}
+		return cb(address, &net.TCPAddr{IP: net.ParseIP(host), Port: portNumber}, key)
+	}
 }
 
 // pipeSession shuttles bytes + window changes between the outer session

--- a/internal/domain/access/handler.go
+++ b/internal/domain/access/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -224,7 +225,8 @@ func (h *Handler) WebConsole(c *gin.Context) {
 }
 
 func (h *Handler) bridgeWebConsole(ws *websocket.Conn, console *consoleSession) error {
-	tcpConn, err := dialViaNSProxy(h.NSProxySockPath, console.Host+":22")
+	sshAddress := net.JoinHostPort(console.Host, "22")
+	tcpConn, err := dialViaNSProxy(h.NSProxySockPath, sshAddress)
 	if err != nil {
 		return err
 	}
@@ -235,10 +237,10 @@ func (h *Handler) bridgeWebConsole(ws *websocket.Conn, console *consoleSession) 
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(console.Signer),
 		},
-		HostKeyCallback: h.VMHostKeyCallback,
+		HostKeyCallback: vmHostKeyCallbackForAddress(sshAddress, h.VMHostKeyCallback),
 	}
 
-	sshConn, chans, reqs, err := ssh.NewClientConn(tcpConn, console.Host+":22", sshCfg)
+	sshConn, chans, reqs, err := ssh.NewClientConn(tcpConn, sshAddress, sshCfg)
 	if err != nil {
 		return err
 	}
@@ -295,6 +297,20 @@ func reloadingVMHostKeyCallback(path string) ssh.HostKeyCallback {
 			return fmt.Errorf("vm host key trust unavailable at %s: %w", path, err)
 		}
 		return cb(hostname, remote, key)
+	}
+}
+
+func vmHostKeyCallbackForAddress(address string, cb ssh.HostKeyCallback) ssh.HostKeyCallback {
+	return func(_ string, _ net.Addr, key ssh.PublicKey) error {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return err
+		}
+		portNumber, err := strconv.Atoi(port)
+		if err != nil {
+			return err
+		}
+		return cb(address, &net.TCPAddr{IP: net.ParseIP(host), Port: portNumber}, key)
 	}
 }
 

--- a/internal/domain/access/hostkey_test.go
+++ b/internal/domain/access/hostkey_test.go
@@ -39,6 +39,27 @@ func TestLoadVMHostKeyCallbackAcceptsKnownHost(t *testing.T) {
 	}
 }
 
+func TestVMHostKeyCallbackForAddressIgnoresProxyRemoteAddr(t *testing.T) {
+	pub, err := testHostPublicKey()
+	if err != nil {
+		t.Fatalf("public key: %v", err)
+	}
+	knownHostsPath := filepath.Join(t.TempDir(), "known_hosts")
+	line := knownhosts.Line([]string{"10.0.0.7"}, pub)
+	if err := os.WriteFile(knownHostsPath, []byte(line+"\n"), 0o600); err != nil {
+		t.Fatalf("write known_hosts: %v", err)
+	}
+
+	cb, err := loadVMHostKeyCallback(knownHostsPath)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	wrapped := vmHostKeyCallbackForAddress("10.0.0.7:22", cb)
+	if err := wrapped("", &net.UnixAddr{Name: "/run/rcp/ns-proxy.sock", Net: "unix"}, pub); err != nil {
+		t.Fatalf("known host rejected through proxy remote addr: %v", err)
+	}
+}
+
 func TestReloadingVMHostKeyCallbackPicksUpCreatedFile(t *testing.T) {
 	pub, err := testHostPublicKey()
 	if err != nil {


### PR DESCRIPTION
## 요약
- ns-proxy Unix socket 경유 SSH 연결에서 VM host key 검증이 실패하던 문제를 수정했습니다.
- known_hosts 검증 시 socket remote address가 아니라 실제 VM 주소를 사용하도록 보정했습니다.
- web console과 ssh-gateway 양쪽에 회귀 테스트를 추가했습니다.

## 배경
최근 VM host key 검증이 추가되면서, ns-proxy를 경유한 SSH 연결의 `remoteAddr`가 `/run/rcp/ns-proxy.sock`으로 전달되어 known_hosts 검증이 실패했습니다. 이로 인해 web console이 연결 직후 종료될 수 있었습니다.

---
### 수정 전
<img width="374" height="226" alt="image" src="https://github.com/user-attachments/assets/701e80c4-54a8-4a7c-82bd-3271cdd2ac94" />
<img width="573" height="162" alt="image" src="https://github.com/user-attachments/assets/83d29ff1-db18-49a8-95ab-b503b197cb1f" />

### 수정 후
<img width="588" height="584" alt="image" src="https://github.com/user-attachments/assets/e009579c-3fb7-42b4-a7b1-cfbe60c4c24b" />
<img width="568" height="566" alt="image" src="https://github.com/user-attachments/assets/ba7c5b93-b56b-4619-825d-4cfcca51fd09" />
