### PR TITLE
fix: swift 타임아웃 완화

### DIFF
--- a/internal/infrastructure/http/client.go
+++ b/internal/infrastructure/http/client.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-const defaultTimeout = 10 * time.Second
+const defaultTimeout = 5 * time.Minute
 
 type cloudflareTransport struct {
 	rt           http.RoundTripper

--- a/internal/infrastructure/http/client_test.go
+++ b/internal/infrastructure/http/client_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -64,7 +65,7 @@ func TestNewCloudflareClientSetsDefaultTimeout(t *testing.T) {
 	t.Parallel()
 
 	client := NewCloudflareClient("client-id", "client-secret")
-	if client.Timeout != defaultTimeout {
-		t.Fatalf("unexpected timeout: got %s want %s", client.Timeout, defaultTimeout)
+	if client.Timeout < 2*time.Minute {
+		t.Fatalf("timeout is too short for object uploads: got %s want at least 2m", client.Timeout)
 	}
 }


### PR DESCRIPTION
## 요약

  백엔드에서 OpenStack/Swift로 요청할 때 사용하는 HTTP client 기본 timeout을 `10초`에서 `5분`으로 완화했습니다.

  ## 배경

  브라우저 업로드가 100% 완료된 뒤에도 백엔드가 Swift로 객체를 스트리밍하는 시간이 추가로 필요합니다. 기존 `10초` 제한 때문에 Swift PUT 요청이 `context
  deadline exceeded`로 실패할 수 있었습니다.

  ## 변경 사항

  - Cloudflare/OpenStack HTTP client 기본 timeout을 `10s`에서 `5m`으로 변경
  - 객체 업로드에 충분한 timeout인지 검증하는 테스트로 수정

  ## 검증

  - 기존 `10s` 값에서는 수정된 테스트가 실패하는 것 확인
  - `go test ./...` 통과