### PR TITLE
fix(admin): show live OpenStack instance status instead of stale DB value

### DIFF
--- a/internal/domain/admin/handler_test.go
+++ b/internal/domain/admin/handler_test.go
@@ -334,66 +334,43 @@ func TestAdminDashboardEndpointsReturnReadOnlyInventory(t *testing.T) {
 	})
 }
 
-func TestAdminInstancesOverlayLiveOpenStackStatus(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	t.Setenv("RCP_ADMIN_EMAILS", "admin@return.dev")
+func createTestUser(t *testing.T, client *ent.Client, email, name string) *ent.User {
+	t.Helper()
+	return client.User.Create().
+		SetEmail(email).
+		SetName(name).
+		SetGoogleID("google-" + name).
+		SetGoogleAccessToken("access").
+		SetGoogleRefreshToken("refresh").
+		SetGoogleTokenExpiry(time.Now()).
+		SaveX(context.Background())
+}
 
+func createTestInstance(t *testing.T, client *ent.Client, owner *ent.User, openstackID, status string) {
+	t.Helper()
+	client.Instance.Create().
+		SetOwner(owner).
+		SetOpenstackID(openstackID).
+		SetName(openstackID).
+		SetStatus(status).
+		SetImageID("ubuntu").
+		SetFlavorID("m1.small").
+		SetProviderCreatedAt(time.Now()).
+		SaveX(context.Background())
+}
+
+func TestServiceOverlaysLiveInstanceStatus(t *testing.T) {
 	ctx := context.Background()
 	client := newAdminTestClient(t, "admin-live-status")
+	student := createTestUser(t, client, "student@return.dev", "student")
 
-	adminUser := client.User.Create().
-		SetEmail("admin@return.dev").
-		SetName("Admin").
-		SetGoogleID("google-admin").
-		SetGoogleAccessToken("access").
-		SetGoogleRefreshToken("refresh").
-		SetGoogleTokenExpiry(time.Now()).
-		SaveX(ctx)
-	student := client.User.Create().
-		SetEmail("student@return.dev").
-		SetName("Student").
-		SetGoogleID("google-student").
-		SetGoogleAccessToken("access").
-		SetGoogleRefreshToken("refresh").
-		SetGoogleTokenExpiry(time.Now()).
-		SaveX(ctx)
+	// DB status is stale ("BUILD"); vm-gone is absent from live data.
+	createTestInstance(t, client, student, "vm-live", "BUILD")
+	createTestInstance(t, client, student, "vm-gone", "BUILD")
 
-	// DB rows persist the status captured at creation time (stale).
-	client.Instance.Create().
-		SetOwner(student).
-		SetOpenstackID("vm-live").
-		SetName("khu-vm3").
-		SetStatus("BUILD").
-		SetImageID("ubuntu").
-		SetFlavorID("m1.small").
-		SetProviderCreatedAt(time.Now()).
-		SaveX(ctx)
-	client.Instance.Create().
-		SetOwner(student).
-		SetOpenstackID("vm-gone").
-		SetName("orphan").
-		SetStatus("BUILD").
-		SetImageID("ubuntu").
-		SetFlavorID("m1.small").
-		SetProviderCreatedAt(time.Now()).
-		SaveX(ctx)
-
-	statusSource := fakeInstanceStatusSource{statuses: map[string]string{
-		"vm-live": "ACTIVE",
-		// vm-gone is intentionally absent from live data.
-	}}
-
-	router := gin.New()
-	group := router.Group("/api/v1")
-	group.Use(func(c *gin.Context) {
-		c.Set(auth.ContextKeyUser, &auth.User{
-			ID:    adminUser.ID,
-			Email: adminUser.Email,
-			Name:  adminUser.Name,
-		})
+	svc := NewService(NewRepository(client), nil, fakeInstanceStatusSource{
+		statuses: map[string]string{"vm-live": "ACTIVE"},
 	})
-	group.Use(auth.AdminRequired())
-	Init(client, WithInstanceStatusSource(statusSource)).InitRoutes(group)
 
 	statusOf := func(items []InstanceResponse, id string) string {
 		for _, item := range items {
@@ -405,122 +382,50 @@ func TestAdminInstancesOverlayLiveOpenStackStatus(t *testing.T) {
 		return ""
 	}
 
-	t.Run("instances list reflects live status", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/instances?page=1&limit=10", nil)
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
+	list, err := svc.Instances(ctx, "1", "10")
+	if err != nil {
+		t.Fatalf("Instances: %v", err)
+	}
+	if got := statusOf(list.Items, "vm-live"); got != "ACTIVE" {
+		t.Fatalf("list: expected ACTIVE, got %q", got)
+	}
+	if got := statusOf(list.Items, "vm-gone"); got != "BUILD" {
+		t.Fatalf("list: expected fallback BUILD, got %q", got)
+	}
 
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-		}
-		var body PaginatedInstancesResponse
-		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-			t.Fatalf("decode instances: %v", err)
-		}
-		if got := statusOf(body.Items, "vm-live"); got != "ACTIVE" {
-			t.Fatalf("expected live status ACTIVE, got %q", got)
-		}
-		// Not present in live data: keep the DB value rather than inventing one.
-		if got := statusOf(body.Items, "vm-gone"); got != "BUILD" {
-			t.Fatalf("expected fallback BUILD, got %q", got)
-		}
-	})
+	detail, err := svc.Instance(ctx, "vm-live")
+	if err != nil {
+		t.Fatalf("Instance: %v", err)
+	}
+	if detail.Status != "ACTIVE" {
+		t.Fatalf("detail: expected ACTIVE, got %q", detail.Status)
+	}
 
-	t.Run("instance detail reflects live status", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/instances/vm-live", nil)
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-		}
-		var body InstanceResponse
-		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-			t.Fatalf("decode instance detail: %v", err)
-		}
-		if body.Status != "ACTIVE" {
-			t.Fatalf("expected live status ACTIVE, got %q", body.Status)
-		}
-	})
-
-	t.Run("user resources reflect live status", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users/"+student.ID.String()+"/resources", nil)
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-		}
-		var body UserResourcesResponse
-		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-			t.Fatalf("decode resources: %v", err)
-		}
-		if got := statusOf(body.Instances, "vm-live"); got != "ACTIVE" {
-			t.Fatalf("expected live status ACTIVE, got %q", got)
-		}
-	})
+	res, err := svc.UserResources(ctx, student.ID.String())
+	if err != nil {
+		t.Fatalf("UserResources: %v", err)
+	}
+	if got := statusOf(res.Instances, "vm-live"); got != "ACTIVE" {
+		t.Fatalf("user resources: expected ACTIVE, got %q", got)
+	}
 }
 
-func TestAdminInstancesFallBackToDBStatusWhenLiveFetchFails(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	t.Setenv("RCP_ADMIN_EMAILS", "admin@return.dev")
-
+func TestServiceFallsBackToDBStatusWhenLiveFetchFails(t *testing.T) {
 	ctx := context.Background()
 	client := newAdminTestClient(t, "admin-live-status-error")
+	student := createTestUser(t, client, "student@return.dev", "student")
+	createTestInstance(t, client, student, "vm-live", "ACTIVE")
 
-	adminUser := client.User.Create().
-		SetEmail("admin@return.dev").
-		SetName("Admin").
-		SetGoogleID("google-admin").
-		SetGoogleAccessToken("access").
-		SetGoogleRefreshToken("refresh").
-		SetGoogleTokenExpiry(time.Now()).
-		SaveX(ctx)
-	student := client.User.Create().
-		SetEmail("student@return.dev").
-		SetName("Student").
-		SetGoogleID("google-student").
-		SetGoogleAccessToken("access").
-		SetGoogleRefreshToken("refresh").
-		SetGoogleTokenExpiry(time.Now()).
-		SaveX(ctx)
-	client.Instance.Create().
-		SetOwner(student).
-		SetOpenstackID("vm-live").
-		SetName("khu-vm3").
-		SetStatus("ACTIVE").
-		SetImageID("ubuntu").
-		SetFlavorID("m1.small").
-		SetProviderCreatedAt(time.Now()).
-		SaveX(ctx)
-
-	statusSource := fakeInstanceStatusSource{err: errors.New("openstack unreachable")}
-
-	router := gin.New()
-	group := router.Group("/api/v1")
-	group.Use(func(c *gin.Context) {
-		c.Set(auth.ContextKeyUser, &auth.User{
-			ID:    adminUser.ID,
-			Email: adminUser.Email,
-			Name:  adminUser.Name,
-		})
+	svc := NewService(NewRepository(client), nil, fakeInstanceStatusSource{
+		err: errors.New("openstack unreachable"),
 	})
-	group.Use(auth.AdminRequired())
-	Init(client, WithInstanceStatusSource(statusSource)).InitRoutes(group)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/instances?page=1&limit=10", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 despite live fetch failure, got %d: %s", w.Code, w.Body.String())
+	list, err := svc.Instances(ctx, "1", "10")
+	if err != nil {
+		t.Fatalf("Instances: %v", err)
 	}
-	var body PaginatedInstancesResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode instances: %v", err)
-	}
-	if len(body.Items) != 1 || body.Items[0].Status != "ACTIVE" {
-		t.Fatalf("expected DB status fallback, got %+v", body.Items)
+	if len(list.Items) != 1 || list.Items[0].Status != "ACTIVE" {
+		t.Fatalf("expected DB status fallback, got %+v", list.Items)
 	}
 }
 

--- a/internal/domain/admin/handler_test.go
+++ b/internal/domain/admin/handler_test.go
@@ -35,6 +35,22 @@ func (f fakeHealthChecker) CheckSSHGateway(context.Context) error { return f.ssh
 func (f fakeHealthChecker) CheckNSProxy(context.Context) error    { return f.nsErr }
 func (f fakeHealthChecker) CheckHTTPProxy(context.Context) error  { return f.httpErr }
 
+type fakeInstanceStatusSource struct {
+	statuses map[string]string
+	err      error
+}
+
+func (f fakeInstanceStatusSource) InstanceStatuses(context.Context) (map[string]string, error) {
+	return f.statuses, f.err
+}
+
+func (f fakeInstanceStatusSource) InstanceStatus(_ context.Context, id string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.statuses[id], nil
+}
+
 func newAdminTestClient(t *testing.T, name string) *ent.Client {
 	t.Helper()
 
@@ -316,6 +332,196 @@ func TestAdminDashboardEndpointsReturnReadOnlyInventory(t *testing.T) {
 			t.Fatalf("unexpected keypair resources: %+v", body.Keypairs)
 		}
 	})
+}
+
+func TestAdminInstancesOverlayLiveOpenStackStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("RCP_ADMIN_EMAILS", "admin@return.dev")
+
+	ctx := context.Background()
+	client := newAdminTestClient(t, "admin-live-status")
+
+	adminUser := client.User.Create().
+		SetEmail("admin@return.dev").
+		SetName("Admin").
+		SetGoogleID("google-admin").
+		SetGoogleAccessToken("access").
+		SetGoogleRefreshToken("refresh").
+		SetGoogleTokenExpiry(time.Now()).
+		SaveX(ctx)
+	student := client.User.Create().
+		SetEmail("student@return.dev").
+		SetName("Student").
+		SetGoogleID("google-student").
+		SetGoogleAccessToken("access").
+		SetGoogleRefreshToken("refresh").
+		SetGoogleTokenExpiry(time.Now()).
+		SaveX(ctx)
+
+	// DB rows persist the status captured at creation time (stale).
+	client.Instance.Create().
+		SetOwner(student).
+		SetOpenstackID("vm-live").
+		SetName("khu-vm3").
+		SetStatus("BUILD").
+		SetImageID("ubuntu").
+		SetFlavorID("m1.small").
+		SetProviderCreatedAt(time.Now()).
+		SaveX(ctx)
+	client.Instance.Create().
+		SetOwner(student).
+		SetOpenstackID("vm-gone").
+		SetName("orphan").
+		SetStatus("BUILD").
+		SetImageID("ubuntu").
+		SetFlavorID("m1.small").
+		SetProviderCreatedAt(time.Now()).
+		SaveX(ctx)
+
+	statusSource := fakeInstanceStatusSource{statuses: map[string]string{
+		"vm-live": "ACTIVE",
+		// vm-gone is intentionally absent from live data.
+	}}
+
+	router := gin.New()
+	group := router.Group("/api/v1")
+	group.Use(func(c *gin.Context) {
+		c.Set(auth.ContextKeyUser, &auth.User{
+			ID:    adminUser.ID,
+			Email: adminUser.Email,
+			Name:  adminUser.Name,
+		})
+	})
+	group.Use(auth.AdminRequired())
+	Init(client, WithInstanceStatusSource(statusSource)).InitRoutes(group)
+
+	statusOf := func(items []InstanceResponse, id string) string {
+		for _, item := range items {
+			if item.ID == id {
+				return item.Status
+			}
+		}
+		t.Fatalf("instance %s missing from %+v", id, items)
+		return ""
+	}
+
+	t.Run("instances list reflects live status", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/instances?page=1&limit=10", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var body PaginatedInstancesResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode instances: %v", err)
+		}
+		if got := statusOf(body.Items, "vm-live"); got != "ACTIVE" {
+			t.Fatalf("expected live status ACTIVE, got %q", got)
+		}
+		// Not present in live data: keep the DB value rather than inventing one.
+		if got := statusOf(body.Items, "vm-gone"); got != "BUILD" {
+			t.Fatalf("expected fallback BUILD, got %q", got)
+		}
+	})
+
+	t.Run("instance detail reflects live status", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/instances/vm-live", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var body InstanceResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode instance detail: %v", err)
+		}
+		if body.Status != "ACTIVE" {
+			t.Fatalf("expected live status ACTIVE, got %q", body.Status)
+		}
+	})
+
+	t.Run("user resources reflect live status", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users/"+student.ID.String()+"/resources", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var body UserResourcesResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode resources: %v", err)
+		}
+		if got := statusOf(body.Instances, "vm-live"); got != "ACTIVE" {
+			t.Fatalf("expected live status ACTIVE, got %q", got)
+		}
+	})
+}
+
+func TestAdminInstancesFallBackToDBStatusWhenLiveFetchFails(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("RCP_ADMIN_EMAILS", "admin@return.dev")
+
+	ctx := context.Background()
+	client := newAdminTestClient(t, "admin-live-status-error")
+
+	adminUser := client.User.Create().
+		SetEmail("admin@return.dev").
+		SetName("Admin").
+		SetGoogleID("google-admin").
+		SetGoogleAccessToken("access").
+		SetGoogleRefreshToken("refresh").
+		SetGoogleTokenExpiry(time.Now()).
+		SaveX(ctx)
+	student := client.User.Create().
+		SetEmail("student@return.dev").
+		SetName("Student").
+		SetGoogleID("google-student").
+		SetGoogleAccessToken("access").
+		SetGoogleRefreshToken("refresh").
+		SetGoogleTokenExpiry(time.Now()).
+		SaveX(ctx)
+	client.Instance.Create().
+		SetOwner(student).
+		SetOpenstackID("vm-live").
+		SetName("khu-vm3").
+		SetStatus("ACTIVE").
+		SetImageID("ubuntu").
+		SetFlavorID("m1.small").
+		SetProviderCreatedAt(time.Now()).
+		SaveX(ctx)
+
+	statusSource := fakeInstanceStatusSource{err: errors.New("openstack unreachable")}
+
+	router := gin.New()
+	group := router.Group("/api/v1")
+	group.Use(func(c *gin.Context) {
+		c.Set(auth.ContextKeyUser, &auth.User{
+			ID:    adminUser.ID,
+			Email: adminUser.Email,
+			Name:  adminUser.Name,
+		})
+	})
+	group.Use(auth.AdminRequired())
+	Init(client, WithInstanceStatusSource(statusSource)).InitRoutes(group)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/instances?page=1&limit=10", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 despite live fetch failure, got %d: %s", w.Code, w.Body.String())
+	}
+	var body PaginatedInstancesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode instances: %v", err)
+	}
+	if len(body.Items) != 1 || body.Items[0].Status != "ACTIVE" {
+		t.Fatalf("expected DB status fallback, got %+v", body.Items)
+	}
 }
 
 func TestAdminSystemReturnsRealHealthStatuses(t *testing.T) {

--- a/internal/domain/admin/init.go
+++ b/internal/domain/admin/init.go
@@ -9,7 +9,8 @@ import (
 type Option func(*options)
 
 type options struct {
-	health healthChecker
+	health       healthChecker
+	statusSource instanceStatusSource
 }
 
 func WithHealthChecker(health healthChecker) Option {
@@ -22,12 +23,22 @@ func WithLiveHealthChecker(provider *gophercloud.ProviderClient, sshGatewaySock,
 	return WithHealthChecker(NewLiveHealthChecker(provider, sshGatewaySock, nsProxySock, httpProxyAddress))
 }
 
+func WithInstanceStatusSource(source instanceStatusSource) Option {
+	return func(opts *options) {
+		opts.statusSource = source
+	}
+}
+
+func WithLiveInstanceStatusSource(provider *gophercloud.ProviderClient) Option {
+	return WithInstanceStatusSource(NewLiveInstanceStatusSource(provider))
+}
+
 func Init(entClient *ent.Client, opts ...Option) *Handler {
 	cfg := options{}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 	repo := NewRepository(entClient)
-	svc := NewService(repo, cfg.health)
+	svc := NewService(repo, cfg.health, cfg.statusSource)
 	return NewHandler(svc)
 }

--- a/internal/domain/admin/instance_status.go
+++ b/internal/domain/admin/instance_status.go
@@ -1,0 +1,44 @@
+package admin
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud"
+
+	"github.com/KHU-RETURN/rcp-server/internal/domain/compute"
+)
+
+type instanceStatusSource interface {
+	InstanceStatuses(ctx context.Context) (map[string]string, error)
+	InstanceStatus(ctx context.Context, id string) (string, error)
+}
+
+// liveInstanceStatusSource reuses the compute client so the admin views read the
+// same live OpenStack status as the user-facing compute views.
+type liveInstanceStatusSource struct {
+	client *compute.Client
+}
+
+func NewLiveInstanceStatusSource(provider *gophercloud.ProviderClient) instanceStatusSource {
+	return &liveInstanceStatusSource{client: compute.NewClient(provider)}
+}
+
+func (s *liveInstanceStatusSource) InstanceStatuses(context.Context) (map[string]string, error) {
+	servers, err := s.client.FetchInstances()
+	if err != nil {
+		return nil, err
+	}
+	statuses := make(map[string]string, len(servers))
+	for _, srv := range servers {
+		statuses[srv.ID] = srv.Status
+	}
+	return statuses, nil
+}
+
+func (s *liveInstanceStatusSource) InstanceStatus(_ context.Context, id string) (string, error) {
+	srv, err := s.client.FetchInstance(id)
+	if err != nil {
+		return "", err
+	}
+	return srv.Status, nil
+}

--- a/internal/domain/admin/service.go
+++ b/internal/domain/admin/service.go
@@ -13,12 +13,13 @@ const (
 )
 
 type Service struct {
-	repo   *Repository
-	health healthChecker
+	repo         *Repository
+	health       healthChecker
+	statusSource instanceStatusSource
 }
 
-func NewService(repo *Repository, health healthChecker) *Service {
-	return &Service{repo: repo, health: health}
+func NewService(repo *Repository, health healthChecker, statusSource instanceStatusSource) *Service {
+	return &Service{repo: repo, health: health, statusSource: statusSource}
 }
 
 func (s *Service) Summary(ctx context.Context) (SummaryResponse, error) {
@@ -30,11 +31,25 @@ func (s *Service) Users(ctx context.Context, rawPage, rawLimit string) (Paginate
 }
 
 func (s *Service) Instances(ctx context.Context, rawPage, rawLimit string) (PaginatedInstancesResponse, error) {
-	return s.repo.Instances(ctx, parsePageParams(rawPage, rawLimit))
+	res, err := s.repo.Instances(ctx, parsePageParams(rawPage, rawLimit))
+	if err != nil {
+		return PaginatedInstancesResponse{}, err
+	}
+	s.overlayLiveStatuses(ctx, res.Items)
+	return res, nil
 }
 
 func (s *Service) Instance(ctx context.Context, id string) (InstanceResponse, error) {
-	return s.repo.Instance(ctx, id)
+	res, err := s.repo.Instance(ctx, id)
+	if err != nil {
+		return InstanceResponse{}, err
+	}
+	if s.statusSource != nil {
+		if live, statusErr := s.statusSource.InstanceStatus(ctx, res.ID); statusErr == nil && live != "" {
+			res.Status = live
+		}
+	}
+	return res, nil
 }
 
 func (s *Service) Containers(ctx context.Context, rawPage, rawLimit string) (PaginatedContainersResponse, error) {
@@ -46,7 +61,28 @@ func (s *Service) Container(ctx context.Context, id string) (ContainerResponse, 
 }
 
 func (s *Service) UserResources(ctx context.Context, id string) (UserResourcesResponse, error) {
-	return s.repo.UserResources(ctx, id)
+	res, err := s.repo.UserResources(ctx, id)
+	if err != nil {
+		return UserResourcesResponse{}, err
+	}
+	s.overlayLiveStatuses(ctx, res.Instances)
+	return res, nil
+}
+
+// overlayLiveStatuses replaces stale DB statuses with live OpenStack statuses, best-effort.
+func (s *Service) overlayLiveStatuses(ctx context.Context, items []InstanceResponse) {
+	if s.statusSource == nil || len(items) == 0 {
+		return
+	}
+	statuses, err := s.statusSource.InstanceStatuses(ctx)
+	if err != nil {
+		return
+	}
+	for i := range items {
+		if live, ok := statuses[items[i].ID]; ok && live != "" {
+			items[i].Status = live
+		}
+	}
 }
 
 func (s *Service) System(ctx context.Context) SystemResponse {

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -54,6 +54,7 @@ func NewApp(deps AppDeps) (*App, error) {
 		Admin: admin.Init(
 			deps.EntClient,
 			admin.WithLiveHealthChecker(deps.Provider, deps.SSHGatewaySock, deps.NSProxySock, deps.HTTPProxyAddress),
+			admin.WithLiveInstanceStatusSource(deps.Provider),
 		),
 		Apps:    apps.Init(deps.EntClient),
 		Auth:    authHandler,


### PR DESCRIPTION
## 개요
어드민 대시보드에서 며칠 전 생성한 인스턴스가 계속 "생성 중(BUILD)”으로 표시되던 버그 수정.

## 원인
어드민 API는 DB에 저장된 `status`를 그대로 노출했는데, 이 값은 인스턴스 생성 시 한 번("BUILD") 기록되고 이후 어디서도 갱신되지 않음. 반면 일반 Compute 화면은 OpenStack을 실시간 조회해 `srv.Status`를 사용하므로 정상 표시됨. 즉 어드민만 stale한 DB 값을 보여주고 있었음.

## 수정
어드민도 일반 Compute와 동일하게 라이브 OpenStack 상태를 overlay.
  - `instanceStatusSource` 인터페이스 추가, 기존 `compute.Client`를 재사용
  (단일 OpenStack
    프로젝트라 `servers.List` 한 번으로 전 유저 인스턴스 커버, 같은
  provider 재사용)
  - `Instances` / `Instance` / `UserResources`에서 DB 조회 후 라이브 상태로
  덮어씀
  - best-effort: 라이브 fetch 실패 시 DB 값으로 폴백 → OpenStack 일시
  장애가 어드민 전체를 깨지 않음

  ## 변경 파일
  - `internal/domain/admin/instance_status.go` (신규) — compute.Client 기반 라이브 상태 소스
  - `internal/domain/admin/service.go` — overlay 로직
  - `internal/domain/admin/init.go` — `WithLiveInstanceStatusSource` 옵션
  - `internal/server/app.go` — provider 와이어링
  - `internal/domain/admin/handler_test.go` — 회귀 테스트