### PR TITLE
feat(access): migrate web console to coder/websocket with buffered relay and liveness keepalive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.4
 
 require (
 	entgo.io/ent v0.14.6
+	github.com/coder/websocket v1.8.14
 	github.com/gin-gonic/gin v1.12.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/domain/access/console_liveness.go
+++ b/internal/domain/access/console_liveness.go
@@ -1,0 +1,134 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	webConsoleKeepaliveInterval = 30 * time.Second
+	webConsoleProbeTimeout      = 10 * time.Second
+	webConsoleIdleTimeout       = 30 * time.Minute
+	webConsoleMaxLifetime       = 12 * time.Hour
+)
+
+var (
+	errConsoleIdle     = errors.New("console idle timeout exceeded")
+	errConsoleLifetime = errors.New("console max lifetime exceeded")
+)
+
+// consoleProbe checks one liveness dimension of an idle console (e.g. the
+// WebSocket peer or the SSH transport) without generating terminal traffic.
+type consoleProbe func(context.Context) error
+
+// consoleLiveness decides when an interactive console must be torn down:
+// idle too long, alive past the absolute cap, or a liveness probe failing.
+// Idle detection matters because a dead peer is otherwise only noticed when
+// terminal output forces a write.
+type consoleLiveness struct {
+	started     time.Time
+	idleTimeout time.Duration
+	maxLifetime time.Duration
+	probes      []consoleProbe
+	lastActive  atomic.Int64 // unix nanoseconds
+}
+
+func newConsoleLiveness(now time.Time, idleTimeout, maxLifetime time.Duration, probes ...consoleProbe) *consoleLiveness {
+	l := &consoleLiveness{
+		started:     now,
+		idleTimeout: idleTimeout,
+		maxLifetime: maxLifetime,
+		probes:      probes,
+	}
+	l.touch(now)
+	return l
+}
+
+func (l *consoleLiveness) touch(now time.Time) {
+	l.lastActive.Store(now.UnixNano())
+}
+
+func (l *consoleLiveness) check(ctx context.Context, now time.Time) error {
+	if now.Sub(l.started) >= l.maxLifetime {
+		return errConsoleLifetime
+	}
+	if now.Sub(time.Unix(0, l.lastActive.Load())) >= l.idleTimeout {
+		return errConsoleIdle
+	}
+	for _, probe := range l.probes {
+		if err := probe(ctx); err != nil {
+			return fmt.Errorf("console liveness probe failed: %w", err)
+		}
+	}
+	return nil
+}
+
+// trackedConsole stamps liveness on every successful client read/write so the
+// idle timeout only fires on genuinely quiet sessions.
+type trackedConsole struct {
+	io.ReadWriteCloser
+	liveness *consoleLiveness
+}
+
+func (t *trackedConsole) Read(p []byte) (int, error) {
+	n, err := t.ReadWriteCloser.Read(p)
+	if n > 0 {
+		t.liveness.touch(time.Now())
+	}
+	return n, err
+}
+
+func (t *trackedConsole) Write(p []byte) (int, error) {
+	n, err := t.ReadWriteCloser.Write(p)
+	if n > 0 {
+		t.liveness.touch(time.Now())
+	}
+	return n, err
+}
+
+// watchConsole periodically checks liveness and cancels the relay with the
+// failure as cause, so teardown logs say why the session ended.
+func watchConsole(ctx context.Context, cancel context.CancelCauseFunc, interval time.Duration, liveness *consoleLiveness) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			probeCtx, probeCancel := context.WithTimeout(ctx, webConsoleProbeTimeout)
+			err := liveness.check(probeCtx, time.Now())
+			probeCancel()
+			if err != nil {
+				cancel(err)
+				return
+			}
+		}
+	}
+}
+
+// sshKeepaliveProbe detects a dead VM or proxy path on an idle session, like
+// OpenSSH's ServerAliveInterval. SendRequest has no context support, so the
+// reply is awaited in a goroutine; on timeout the goroutine is abandoned and
+// reclaimed when the connection closes at teardown.
+func sshKeepaliveProbe(conn ssh.Conn) consoleProbe {
+	return func(ctx context.Context) error {
+		done := make(chan error, 1)
+		go func() {
+			_, _, err := conn.SendRequest("keepalive@openssh.com", true, nil)
+			done <- err
+		}()
+		select {
+		case err := <-done:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/internal/domain/access/console_liveness_test.go
+++ b/internal/domain/access/console_liveness_test.go
@@ -1,0 +1,270 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestConsoleLivenessCheck(t *testing.T) {
+	t0 := time.Unix(1_000_000, 0)
+	probeErr := errors.New("probe boom")
+
+	tests := []struct {
+		name    string
+		probes  []consoleProbe
+		now     time.Time
+		wantErr error
+	}{
+		{
+			name: "passes while active and within lifetime",
+			now:  t0.Add(time.Minute),
+		},
+		{
+			name:    "fails after idle timeout",
+			now:     t0.Add(webConsoleIdleTimeout + time.Second),
+			wantErr: errConsoleIdle,
+		},
+		{
+			name:    "fails after max lifetime",
+			now:     t0.Add(webConsoleMaxLifetime + time.Second),
+			wantErr: errConsoleLifetime,
+		},
+		{
+			name:    "fails when a probe fails",
+			probes:  []consoleProbe{func(context.Context) error { return probeErr }},
+			now:     t0.Add(time.Minute),
+			wantErr: probeErr,
+		},
+		{
+			name: "passes when probes succeed",
+			probes: []consoleProbe{
+				func(context.Context) error { return nil },
+				func(context.Context) error { return nil },
+			},
+			now: t0.Add(time.Minute),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := newConsoleLiveness(t0, webConsoleIdleTimeout, webConsoleMaxLifetime, tt.probes...)
+			err := l.check(context.Background(), tt.now)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("check() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestConsoleLivenessTouchResetsIdle(t *testing.T) {
+	t0 := time.Unix(1_000_000, 0)
+	l := newConsoleLiveness(t0, webConsoleIdleTimeout, webConsoleMaxLifetime)
+
+	stale := t0.Add(webConsoleIdleTimeout + time.Second)
+	if err := l.check(context.Background(), stale); !errors.Is(err, errConsoleIdle) {
+		t.Fatalf("check() before touch = %v, want %v", err, errConsoleIdle)
+	}
+
+	l.touch(stale)
+	if err := l.check(context.Background(), stale); err != nil {
+		t.Fatalf("check() after touch = %v, want nil", err)
+	}
+}
+
+type fakeRWC struct {
+	readData []byte
+	closed   bool
+}
+
+func (f *fakeRWC) Read(p []byte) (int, error) {
+	if len(f.readData) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, f.readData)
+	f.readData = f.readData[n:]
+	return n, nil
+}
+
+func (f *fakeRWC) Write(p []byte) (int, error) { return len(p), nil }
+func (f *fakeRWC) Close() error                { f.closed = true; return nil }
+
+func TestTrackedConsoleStampsActivity(t *testing.T) {
+	t0 := time.Unix(1_000_000, 0)
+	idleAt := t0.Add(webConsoleIdleTimeout + time.Second)
+
+	t.Run("read resets idle clock", func(t *testing.T) {
+		l := newConsoleLiveness(t0, webConsoleIdleTimeout, webConsoleMaxLifetime)
+		tracked := &trackedConsole{ReadWriteCloser: &fakeRWC{readData: []byte("ls\n")}, liveness: l}
+
+		buf := make([]byte, 8)
+		if _, err := tracked.Read(buf); err != nil {
+			t.Fatalf("Read() error = %v", err)
+		}
+		if err := l.check(context.Background(), idleAt); errors.Is(err, errConsoleIdle) {
+			t.Fatal("check() reported idle right after a read")
+		}
+	})
+
+	t.Run("write resets idle clock", func(t *testing.T) {
+		l := newConsoleLiveness(t0, webConsoleIdleTimeout, webConsoleMaxLifetime)
+		tracked := &trackedConsole{ReadWriteCloser: &fakeRWC{}, liveness: l}
+
+		if _, err := tracked.Write([]byte("output")); err != nil {
+			t.Fatalf("Write() error = %v", err)
+		}
+		if err := l.check(context.Background(), idleAt); errors.Is(err, errConsoleIdle) {
+			t.Fatal("check() reported idle right after a write")
+		}
+	})
+}
+
+func TestWatchConsoleCancelsWithCause(t *testing.T) {
+	probeErr := errors.New("dead transport")
+	l := newConsoleLiveness(time.Now(), webConsoleIdleTimeout, webConsoleMaxLifetime,
+		func(context.Context) error { return probeErr })
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	go watchConsole(ctx, cancel, time.Millisecond, l)
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchConsole did not cancel on probe failure")
+	}
+	if cause := context.Cause(ctx); !errors.Is(cause, probeErr) {
+		t.Fatalf("context cause = %v, want %v", cause, probeErr)
+	}
+}
+
+func TestWatchConsoleStopsWhenContextDone(t *testing.T) {
+	l := newConsoleLiveness(time.Now(), webConsoleIdleTimeout, webConsoleMaxLifetime)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	stopped := make(chan struct{})
+	go func() {
+		watchConsole(ctx, cancel, time.Millisecond, l)
+		close(stopped)
+	}()
+
+	cancel(nil)
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchConsole did not stop after context cancellation")
+	}
+}
+
+type fakeSSHConn struct {
+	ssh.Conn
+	sendRequest func(name string, wantReply bool, payload []byte) (bool, []byte, error)
+}
+
+func (f *fakeSSHConn) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+	return f.sendRequest(name, wantReply, payload)
+}
+
+func TestSSHKeepaliveProbe(t *testing.T) {
+	t.Run("sends openssh keepalive and succeeds", func(t *testing.T) {
+		var gotName string
+		var gotWantReply bool
+		conn := &fakeSSHConn{sendRequest: func(name string, wantReply bool, _ []byte) (bool, []byte, error) {
+			gotName, gotWantReply = name, wantReply
+			return false, nil, nil
+		}}
+
+		if err := sshKeepaliveProbe(conn)(context.Background()); err != nil {
+			t.Fatalf("probe error = %v, want nil", err)
+		}
+		if gotName != "keepalive@openssh.com" || !gotWantReply {
+			t.Fatalf("SendRequest(%q, %v), want (keepalive@openssh.com, true)", gotName, gotWantReply)
+		}
+	})
+
+	t.Run("propagates transport error", func(t *testing.T) {
+		sendErr := errors.New("connection lost")
+		conn := &fakeSSHConn{sendRequest: func(string, bool, []byte) (bool, []byte, error) {
+			return false, nil, sendErr
+		}}
+
+		if err := sshKeepaliveProbe(conn)(context.Background()); !errors.Is(err, sendErr) {
+			t.Fatalf("probe error = %v, want %v", err, sendErr)
+		}
+	})
+
+	t.Run("honors context when request hangs", func(t *testing.T) {
+		block := make(chan struct{})
+		defer close(block)
+		conn := &fakeSSHConn{sendRequest: func(string, bool, []byte) (bool, []byte, error) {
+			<-block
+			return false, nil, nil
+		}}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := sshKeepaliveProbe(conn)(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("probe error = %v, want %v", err, context.Canceled)
+		}
+	})
+}
+
+func TestWebSocketConsolePing(t *testing.T) {
+	consoles := make(chan *webSocketConsole, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		consoles <- newWebSocketConsole(conn)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clientConn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("websocket.Dial() error = %v", err)
+	}
+	defer func() { _ = clientConn.CloseNow() }()
+	// Both peers must be reading for ping/pong control frames to be processed.
+	go func() {
+		for {
+			if _, _, err := clientConn.Read(context.Background()); err != nil {
+				return
+			}
+		}
+	}()
+
+	console := <-consoles
+	defer func() { _ = console.Close() }()
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			if _, err := console.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	if err := console.Ping(ctx); err != nil {
+		t.Fatalf("Ping() over live connection = %v, want nil", err)
+	}
+
+	_ = clientConn.CloseNow()
+	pingCtx, pingCancel := context.WithTimeout(context.Background(), time.Second)
+	defer pingCancel()
+	if err := console.Ping(pingCtx); err == nil {
+		t.Fatal("Ping() over closed connection = nil, want error")
+	}
+}

--- a/internal/domain/access/handler.go
+++ b/internal/domain/access/handler.go
@@ -1,6 +1,7 @@
 package access
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -17,13 +18,19 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/coder/websocket"
 	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
-	"golang.org/x/net/websocket"
 
 	"github.com/KHU-RETURN/rcp-server/internal/api"
+)
+
+const (
+	webConsoleWriteTimeout = 10 * time.Second
+	webConsoleReadLimit    = 1 << 20
 )
 
 const (
@@ -279,24 +286,37 @@ func (h *Handler) WebConsole(c *gin.Context) {
 		return
 	}
 
-	server := websocket.Server{
-		Handshake: validateWebSocketOrigin,
-		Handler: func(ws *websocket.Conn) {
-			defer func() { _ = ws.Close() }()
-			if err := h.bridgeWebConsole(ws, session); err != nil {
-				slog.Default().Warn("web console bridge failed",
-					"instance_id", session.InstanceID,
-					"host", session.Host,
-					"username", session.Username,
-					"err", err,
-				)
-			}
-		},
+	if !isWebSocketOriginAllowed(c.Request) {
+		c.JSON(http.StatusForbidden, api.ErrorResponse{Error: "websocket origin is not allowed"})
+		return
 	}
-	server.ServeHTTP(c.Writer, c.Request)
+
+	// Origin is validated above; skip the library's built-in check.
+	conn, err := websocket.Accept(c.Writer, c.Request, &websocket.AcceptOptions{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		slog.Default().Warn("web console websocket accept failed",
+			"instance_id", session.InstanceID,
+			"err", err,
+		)
+		return
+	}
+	conn.SetReadLimit(webConsoleReadLimit)
+	defer func() { _ = conn.CloseNow() }()
+
+	if err := h.bridgeWebConsole(conn, session); err != nil {
+		slog.Default().Warn("web console bridge failed",
+			"instance_id", session.InstanceID,
+			"host", session.Host,
+			"username", session.Username,
+			"err", err,
+		)
+	}
+	_ = conn.Close(websocket.StatusNormalClosure, "")
 }
 
-func (h *Handler) bridgeWebConsole(ws *websocket.Conn, console *consoleSession) error {
+func (h *Handler) bridgeWebConsole(conn *websocket.Conn, console *consoleSession) error {
 	sshAddress := net.JoinHostPort(console.Host, "22")
 	tcpConn, err := dialViaNSProxy(h.NSProxySockPath, sshAddress)
 	if err != nil {
@@ -346,15 +366,25 @@ func (h *Handler) bridgeWebConsole(ws *websocket.Conn, console *consoleSession) 
 		return err
 	}
 
-	var writeMu sync.Mutex
-	done := make(chan struct{})
-	go copySSHToWebSocket(ws, stdout, &writeMu, done)
-	go copySSHToWebSocket(ws, stderr, &writeMu, done)
-	go copyWebSocketToSSH(ws, stdin, done)
+	// Background-derived: the request context is canceled once the socket is hijacked.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	err = sess.Wait()
+	var writeMu sync.Mutex
+	go func() { defer cancel(); copySSHToWebSocket(ctx, conn, stdout, &writeMu) }()
+	go func() { defer cancel(); copySSHToWebSocket(ctx, conn, stderr, &writeMu) }()
+	go func() { defer cancel(); copyWebSocketToSSH(ctx, conn, stdin) }()
+
+	waitErr := make(chan error, 1)
+	go func() { waitErr <- sess.Wait() }()
+
+	select {
+	case err = <-waitErr:
+	case <-ctx.Done():
+		_ = sess.Close()
+		err = <-waitErr
+	}
 	h.Svc.DeleteAuthorizedKey(console.InstanceID, console.Username, console.AuthorizedKey)
-	close(done)
 	return err
 }
 
@@ -434,42 +464,39 @@ func loadVMHostKeyCallback(path string) (ssh.HostKeyCallback, error) {
 	return knownhosts.New(clean)
 }
 
-func copySSHToWebSocket(ws *websocket.Conn, r io.Reader, mu *sync.Mutex, done <-chan struct{}) {
+func copySSHToWebSocket(ctx context.Context, conn *websocket.Conn, r io.Reader, mu *sync.Mutex) {
 	buf := make([]byte, 32*1024)
 	for {
 		n, err := r.Read(buf)
 		if n > 0 {
-			payload := append([]byte(nil), buf[:n]...)
+			// conn.Write consumes buf[:n] synchronously; no copy needed.
 			mu.Lock()
-			_ = websocket.Message.Send(ws, payload)
+			writeCtx, writeCancel := context.WithTimeout(ctx, webConsoleWriteTimeout)
+			writeErr := conn.Write(writeCtx, websocket.MessageBinary, buf[:n])
+			writeCancel()
 			mu.Unlock()
+			if writeErr != nil {
+				return
+			}
 		}
 		if err != nil {
 			return
 		}
-		select {
-		case <-done:
-			return
-		default:
-		}
 	}
 }
 
-func copyWebSocketToSSH(ws *websocket.Conn, w io.WriteCloser, done <-chan struct{}) {
+func copyWebSocketToSSH(ctx context.Context, conn *websocket.Conn, w io.WriteCloser) {
 	defer func() { _ = w.Close() }()
 
 	for {
-		var payload []byte
-		if err := websocket.Message.Receive(ws, &payload); err != nil {
+		_, payload, err := conn.Read(ctx)
+		if err != nil {
 			return
 		}
 		if len(payload) > 0 {
-			_, _ = w.Write(payload)
-		}
-		select {
-		case <-done:
-			return
-		default:
+			if _, err := w.Write(payload); err != nil {
+				return
+			}
 		}
 	}
 }
@@ -505,15 +532,8 @@ func configuredWebConsoleBaseURL() string {
 	return strings.TrimRight(parsed.String(), "/")
 }
 
-func validateWebSocketOrigin(config *websocket.Config, req *http.Request) error {
-	if isWebSocketOriginAllowed(config, req) {
-		return nil
-	}
-	return errors.New("websocket origin is not allowed")
-}
-
-func isWebSocketOriginAllowed(config *websocket.Config, req *http.Request) bool {
-	origin, ok := websocketOrigin(config, req)
+func isWebSocketOriginAllowed(req *http.Request) bool {
+	origin, ok := websocketOrigin(req)
 	if !ok {
 		return true
 	}
@@ -533,11 +553,7 @@ func isWebSocketOriginAllowed(config *websocket.Config, req *http.Request) bool 
 	return sameHost(origin.Host, req.Host)
 }
 
-func websocketOrigin(config *websocket.Config, req *http.Request) (*url.URL, bool) {
-	if config != nil && config.Origin != nil {
-		return normalizeOrigin(config.Origin), true
-	}
-
+func websocketOrigin(req *http.Request) (*url.URL, bool) {
 	rawOrigin := strings.TrimSpace(req.Header.Get("Origin"))
 	if rawOrigin == "" {
 		return nil, false

--- a/internal/domain/access/handler.go
+++ b/internal/domain/access/handler.go
@@ -34,6 +34,7 @@ const (
 	webConsoleReadLimit     = 1 << 20
 	webConsoleFlushInterval = 8 * time.Millisecond
 	webConsoleFlushMaxBytes = 64 * 1024
+	webConsoleBufferLimit   = 1 << 20
 )
 
 const (
@@ -479,6 +480,7 @@ type webSocketConsole struct {
 	rest []byte // input leftover; Read is single-threaded
 
 	mu        sync.Mutex
+	cond      *sync.Cond // signaled when buf drains or the console closes
 	buf       []byte
 	closed    bool
 	wake      chan struct{}
@@ -496,6 +498,7 @@ func newWebSocketConsole(conn *websocket.Conn) *webSocketConsole {
 		done:     make(chan struct{}),
 		stopped:  make(chan struct{}),
 	}
+	w.cond = sync.NewCond(&w.mu)
 	go w.flushLoop()
 	return w
 }
@@ -515,6 +518,11 @@ func (w *webSocketConsole) Read(p []byte) (int, error) {
 
 func (w *webSocketConsole) Write(p []byte) (int, error) {
 	w.mu.Lock()
+	// Backpressure: block the producer until the flusher drains below the limit,
+	// throttling the SSH read loop instead of buffering output unbounded.
+	for len(w.buf) >= webConsoleBufferLimit && !w.closed {
+		w.cond.Wait()
+	}
 	if w.closed {
 		w.mu.Unlock()
 		return 0, io.ErrClosedPipe
@@ -534,6 +542,7 @@ func (w *webSocketConsole) Close() error {
 	w.closeOnce.Do(func() {
 		w.mu.Lock()
 		w.closed = true
+		w.cond.Broadcast()
 		w.mu.Unlock()
 		close(w.done)
 	})
@@ -572,6 +581,7 @@ func (w *webSocketConsole) flush() error {
 	}
 	out := w.buf
 	w.buf = nil
+	w.cond.Broadcast()
 	w.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), webConsoleWriteTimeout)
@@ -581,6 +591,7 @@ func (w *webSocketConsole) flush() error {
 		// Slow or dead client: drop further output and force teardown.
 		w.mu.Lock()
 		w.closed = true
+		w.cond.Broadcast()
 		w.mu.Unlock()
 		_ = w.conn.CloseNow()
 	}

--- a/internal/domain/access/handler.go
+++ b/internal/domain/access/handler.go
@@ -29,9 +29,11 @@ import (
 )
 
 const (
-	webConsoleDialTimeout  = 15 * time.Second
-	webConsoleWriteTimeout = 10 * time.Second
-	webConsoleReadLimit    = 1 << 20
+	webConsoleDialTimeout   = 15 * time.Second
+	webConsoleWriteTimeout  = 10 * time.Second
+	webConsoleReadLimit     = 1 << 20
+	webConsoleFlushInterval = 8 * time.Millisecond
+	webConsoleFlushMaxBytes = 64 * 1024
 )
 
 const (
@@ -470,14 +472,32 @@ func loadVMHostKeyCallback(path string) (ssh.HostKeyCallback, error) {
 }
 
 // webSocketConsole adapts a WebSocket to the io.ReadWriteCloser the relay drives.
+// Output is batched: writes accumulate in a buffer that a flush loop drains as one
+// binary frame per interval, cutting frame count on bursty output.
 type webSocketConsole struct {
 	conn *websocket.Conn
-	mu   sync.Mutex
-	rest []byte
+	rest []byte // input leftover; Read is single-threaded
+
+	mu        sync.Mutex
+	buf       []byte
+	closed    bool
+	wake      chan struct{}
+	flushNow  chan struct{}
+	done      chan struct{}
+	stopped   chan struct{}
+	closeOnce sync.Once
 }
 
 func newWebSocketConsole(conn *websocket.Conn) *webSocketConsole {
-	return &webSocketConsole{conn: conn}
+	w := &webSocketConsole{
+		conn:     conn,
+		wake:     make(chan struct{}, 1),
+		flushNow: make(chan struct{}, 1),
+		done:     make(chan struct{}),
+		stopped:  make(chan struct{}),
+	}
+	go w.flushLoop()
+	return w
 }
 
 func (w *webSocketConsole) Read(p []byte) (int, error) {
@@ -495,17 +515,83 @@ func (w *webSocketConsole) Read(p []byte) (int, error) {
 
 func (w *webSocketConsole) Write(p []byte) (int, error) {
 	w.mu.Lock()
-	defer w.mu.Unlock()
-	ctx, cancel := context.WithTimeout(context.Background(), webConsoleWriteTimeout)
-	defer cancel()
-	if err := w.conn.Write(ctx, websocket.MessageBinary, p); err != nil {
-		return 0, err
+	if w.closed {
+		w.mu.Unlock()
+		return 0, io.ErrClosedPipe
+	}
+	w.buf = append(w.buf, p...)
+	large := len(w.buf) >= webConsoleFlushMaxBytes
+	w.mu.Unlock()
+
+	notify(w.wake)
+	if large {
+		notify(w.flushNow)
 	}
 	return len(p), nil
 }
 
 func (w *webSocketConsole) Close() error {
+	w.closeOnce.Do(func() {
+		w.mu.Lock()
+		w.closed = true
+		w.mu.Unlock()
+		close(w.done)
+	})
+	<-w.stopped
 	return w.conn.Close(websocket.StatusNormalClosure, "")
+}
+
+func (w *webSocketConsole) flushLoop() {
+	defer close(w.stopped)
+	for {
+		select {
+		case <-w.done:
+			_ = w.flush()
+			return
+		case <-w.wake:
+			// Accumulate briefly so bursty output coalesces into one frame.
+			select {
+			case <-w.done:
+				_ = w.flush()
+				return
+			case <-w.flushNow:
+			case <-time.After(webConsoleFlushInterval):
+			}
+			if w.flush() != nil {
+				return
+			}
+		}
+	}
+}
+
+func (w *webSocketConsole) flush() error {
+	w.mu.Lock()
+	if len(w.buf) == 0 {
+		w.mu.Unlock()
+		return nil
+	}
+	out := w.buf
+	w.buf = nil
+	w.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), webConsoleWriteTimeout)
+	err := w.conn.Write(ctx, websocket.MessageBinary, out)
+	cancel()
+	if err != nil {
+		// Slow or dead client: drop further output and force teardown.
+		w.mu.Lock()
+		w.closed = true
+		w.mu.Unlock()
+		_ = w.conn.CloseNow()
+	}
+	return err
+}
+
+func notify(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
 }
 
 func websocketBaseURL(c *gin.Context) string {

--- a/internal/domain/access/handler.go
+++ b/internal/domain/access/handler.go
@@ -527,6 +527,9 @@ func (w *webSocketConsole) Write(p []byte) (int, error) {
 		w.mu.Unlock()
 		return 0, io.ErrClosedPipe
 	}
+	if w.buf == nil {
+		w.buf = getWebConsoleBuf()
+	}
 	w.buf = append(w.buf, p...)
 	large := len(w.buf) >= webConsoleFlushMaxBytes
 	w.mu.Unlock()
@@ -587,6 +590,7 @@ func (w *webSocketConsole) flush() error {
 	ctx, cancel := context.WithTimeout(context.Background(), webConsoleWriteTimeout)
 	err := w.conn.Write(ctx, websocket.MessageBinary, out)
 	cancel()
+	putWebConsoleBuf(out) // conn.Write is done with out; reuse its backing array
 	if err != nil {
 		// Slow or dead client: drop further output and force teardown.
 		w.mu.Lock()
@@ -603,6 +607,26 @@ func notify(ch chan struct{}) {
 	case ch <- struct{}{}:
 	default:
 	}
+}
+
+// webConsoleBufPool reuses output buffers across flush cycles to avoid
+// reallocating one per ~8ms window under heavy output.
+var webConsoleBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, webConsoleFlushMaxBytes)
+		return &b
+	},
+}
+
+func getWebConsoleBuf() []byte {
+	return (*webConsoleBufPool.Get().(*[]byte))[:0]
+}
+
+func putWebConsoleBuf(b []byte) {
+	if cap(b) > webConsoleBufferLimit {
+		return // don't retain oversized buffers grown past the cap
+	}
+	webConsoleBufPool.Put(&b)
 }
 
 func websocketBaseURL(c *gin.Context) string {

--- a/internal/domain/access/handler.go
+++ b/internal/domain/access/handler.go
@@ -323,7 +323,8 @@ func (h *Handler) WebConsole(c *gin.Context) {
 func (h *Handler) relayConsole(client io.ReadWriteCloser, console *consoleSession) error {
 	sshAddress := net.JoinHostPort(console.Host, "22")
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancelCause := context.WithCancelCause(context.Background())
+	cancel := func() { cancelCause(nil) }
 	defer cancel()
 
 	dialCtx, dialCancel := context.WithTimeout(ctx, webConsoleDialTimeout)
@@ -377,9 +378,17 @@ func (h *Handler) relayConsole(client io.ReadWriteCloser, console *consoleSessio
 		return err
 	}
 
-	go func() { defer cancel(); _, _ = io.Copy(client, stdout) }()
-	go func() { defer cancel(); _, _ = io.Copy(client, stderr) }()
-	go func() { defer cancel(); _, _ = io.Copy(stdin, client); _ = stdin.Close() }()
+	probes := []consoleProbe{sshKeepaliveProbe(sshConn)}
+	if pinger, ok := client.(interface{ Ping(context.Context) error }); ok {
+		probes = append(probes, pinger.Ping)
+	}
+	liveness := newConsoleLiveness(time.Now(), webConsoleIdleTimeout, webConsoleMaxLifetime, probes...)
+	tracked := &trackedConsole{ReadWriteCloser: client, liveness: liveness}
+	go watchConsole(ctx, cancelCause, webConsoleKeepaliveInterval, liveness)
+
+	go func() { defer cancel(); _, _ = io.Copy(tracked, stdout) }()
+	go func() { defer cancel(); _, _ = io.Copy(tracked, stderr) }()
+	go func() { defer cancel(); _, _ = io.Copy(stdin, tracked); _ = stdin.Close() }()
 
 	waitErr := make(chan error, 1)
 	go func() { waitErr <- sess.Wait() }()
@@ -389,6 +398,10 @@ func (h *Handler) relayConsole(client io.ReadWriteCloser, console *consoleSessio
 	case <-ctx.Done():
 		_ = sess.Close()
 		err = <-waitErr
+		// Prefer the liveness verdict over the generic wait error it caused.
+		if cause := context.Cause(ctx); cause != nil && !errors.Is(cause, context.Canceled) {
+			err = cause
+		}
 	}
 	// Closing the transport unblocks the input pump still reading from the client.
 	_ = client.Close()
@@ -501,6 +514,12 @@ func newWebSocketConsole(conn *websocket.Conn) *webSocketConsole {
 	w.cond = sync.NewCond(&w.mu)
 	go w.flushLoop()
 	return w
+}
+
+// Ping verifies the browser peer is still reachable. Browsers answer
+// protocol-level pings automatically, so this needs no frontend support.
+func (w *webSocketConsole) Ping(ctx context.Context) error {
+	return w.conn.Ping(ctx)
 }
 
 func (w *webSocketConsole) Read(p []byte) (int, error) {

--- a/internal/domain/access/handler.go
+++ b/internal/domain/access/handler.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+	webConsoleDialTimeout  = 15 * time.Second
 	webConsoleWriteTimeout = 10 * time.Second
 	webConsoleReadLimit    = 1 << 20
 )
@@ -305,7 +306,7 @@ func (h *Handler) WebConsole(c *gin.Context) {
 	conn.SetReadLimit(webConsoleReadLimit)
 	defer func() { _ = conn.CloseNow() }()
 
-	if err := h.bridgeWebConsole(conn, session); err != nil {
+	if err := h.relayConsole(newWebSocketConsole(conn), session); err != nil {
 		slog.Default().Warn("web console bridge failed",
 			"instance_id", session.InstanceID,
 			"host", session.Host,
@@ -313,12 +314,18 @@ func (h *Handler) WebConsole(c *gin.Context) {
 			"err", err,
 		)
 	}
-	_ = conn.Close(websocket.StatusNormalClosure, "")
 }
 
-func (h *Handler) bridgeWebConsole(conn *websocket.Conn, console *consoleSession) error {
+// relayConsole runs an SSH shell over a console session against any client transport.
+func (h *Handler) relayConsole(client io.ReadWriteCloser, console *consoleSession) error {
 	sshAddress := net.JoinHostPort(console.Host, "22")
-	tcpConn, err := dialViaNSProxy(h.NSProxySockPath, sshAddress)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dialCtx, dialCancel := context.WithTimeout(ctx, webConsoleDialTimeout)
+	tcpConn, err := dialViaNSProxy(dialCtx, h.NSProxySockPath, sshAddress)
+	dialCancel()
 	if err != nil {
 		return err
 	}
@@ -330,6 +337,7 @@ func (h *Handler) bridgeWebConsole(conn *websocket.Conn, console *consoleSession
 			ssh.PublicKeys(console.Signer),
 		},
 		HostKeyCallback: vmHostKeyCallbackForAddress(sshAddress, h.VMHostKeyCallback),
+		Timeout:         webConsoleDialTimeout,
 	}
 
 	sshConn, chans, reqs, err := ssh.NewClientConn(tcpConn, sshAddress, sshCfg)
@@ -337,10 +345,10 @@ func (h *Handler) bridgeWebConsole(conn *websocket.Conn, console *consoleSession
 		return err
 	}
 	h.Svc.DeleteAuthorizedKey(console.InstanceID, console.Username, console.AuthorizedKey)
-	client := ssh.NewClient(sshConn, chans, reqs)
-	defer func() { _ = client.Close() }()
+	sshClient := ssh.NewClient(sshConn, chans, reqs)
+	defer func() { _ = sshClient.Close() }()
 
-	sess, err := client.NewSession()
+	sess, err := sshClient.NewSession()
 	if err != nil {
 		return err
 	}
@@ -366,14 +374,9 @@ func (h *Handler) bridgeWebConsole(conn *websocket.Conn, console *consoleSession
 		return err
 	}
 
-	// Background-derived: the request context is canceled once the socket is hijacked.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	var writeMu sync.Mutex
-	go func() { defer cancel(); copySSHToWebSocket(ctx, conn, stdout, &writeMu) }()
-	go func() { defer cancel(); copySSHToWebSocket(ctx, conn, stderr, &writeMu) }()
-	go func() { defer cancel(); copyWebSocketToSSH(ctx, conn, stdin) }()
+	go func() { defer cancel(); _, _ = io.Copy(client, stdout) }()
+	go func() { defer cancel(); _, _ = io.Copy(client, stderr) }()
+	go func() { defer cancel(); _, _ = io.Copy(stdin, client); _ = stdin.Close() }()
 
 	waitErr := make(chan error, 1)
 	go func() { waitErr <- sess.Wait() }()
@@ -384,6 +387,8 @@ func (h *Handler) bridgeWebConsole(conn *websocket.Conn, console *consoleSession
 		_ = sess.Close()
 		err = <-waitErr
 	}
+	// Closing the transport unblocks the input pump still reading from the client.
+	_ = client.Close()
 	h.Svc.DeleteAuthorizedKey(console.InstanceID, console.Username, console.AuthorizedKey)
 	return err
 }
@@ -464,41 +469,43 @@ func loadVMHostKeyCallback(path string) (ssh.HostKeyCallback, error) {
 	return knownhosts.New(clean)
 }
 
-func copySSHToWebSocket(ctx context.Context, conn *websocket.Conn, r io.Reader, mu *sync.Mutex) {
-	buf := make([]byte, 32*1024)
-	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			// conn.Write consumes buf[:n] synchronously; no copy needed.
-			mu.Lock()
-			writeCtx, writeCancel := context.WithTimeout(ctx, webConsoleWriteTimeout)
-			writeErr := conn.Write(writeCtx, websocket.MessageBinary, buf[:n])
-			writeCancel()
-			mu.Unlock()
-			if writeErr != nil {
-				return
-			}
-		}
-		if err != nil {
-			return
-		}
-	}
+// webSocketConsole adapts a WebSocket to the io.ReadWriteCloser the relay drives.
+type webSocketConsole struct {
+	conn *websocket.Conn
+	mu   sync.Mutex
+	rest []byte
 }
 
-func copyWebSocketToSSH(ctx context.Context, conn *websocket.Conn, w io.WriteCloser) {
-	defer func() { _ = w.Close() }()
+func newWebSocketConsole(conn *websocket.Conn) *webSocketConsole {
+	return &webSocketConsole{conn: conn}
+}
 
-	for {
-		_, payload, err := conn.Read(ctx)
+func (w *webSocketConsole) Read(p []byte) (int, error) {
+	if len(w.rest) == 0 {
+		_, data, err := w.conn.Read(context.Background())
 		if err != nil {
-			return
+			return 0, err
 		}
-		if len(payload) > 0 {
-			if _, err := w.Write(payload); err != nil {
-				return
-			}
-		}
+		w.rest = data
 	}
+	n := copy(p, w.rest)
+	w.rest = w.rest[n:]
+	return n, nil
+}
+
+func (w *webSocketConsole) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), webConsoleWriteTimeout)
+	defer cancel()
+	if err := w.conn.Write(ctx, websocket.MessageBinary, p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (w *webSocketConsole) Close() error {
+	return w.conn.Close(websocket.StatusNormalClosure, "")
 }
 
 func websocketBaseURL(c *gin.Context) string {

--- a/internal/domain/access/handler_test.go
+++ b/internal/domain/access/handler_test.go
@@ -10,13 +10,11 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"golang.org/x/net/websocket"
 
 	"github.com/KHU-RETURN/rcp-server/internal/api"
 	"github.com/KHU-RETURN/rcp-server/internal/domain/auth"
@@ -95,19 +93,12 @@ func TestValidateWebSocketOrigin(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(envWebConsoleAllowedOrigins, tt.allowedOrigins)
 
-			origin, err := url.Parse(tt.origin)
-			if err != nil {
-				t.Fatalf("parse origin: %v", err)
-			}
 			req := httptest.NewRequest(http.MethodGet, "http://"+tt.host+"/console", nil)
-			cfg := &websocket.Config{Origin: origin}
+			req.Header.Set("Origin", tt.origin)
 
-			err = validateWebSocketOrigin(cfg, req)
-			if tt.wantAllowed && err != nil {
-				t.Fatalf("expected origin to be allowed, got %v", err)
-			}
-			if !tt.wantAllowed && err == nil {
-				t.Fatal("expected origin to be rejected")
+			got := isWebSocketOriginAllowed(req)
+			if got != tt.wantAllowed {
+				t.Fatalf("isWebSocketOriginAllowed() = %v, want %v", got, tt.wantAllowed)
 			}
 		})
 	}

--- a/internal/domain/access/ns_proxy.go
+++ b/internal/domain/access/ns_proxy.go
@@ -1,6 +1,7 @@
 package access
 
 import (
+	"context"
 	"net"
 
 	"golang.org/x/net/proxy"
@@ -10,15 +11,23 @@ type unixForwarder struct {
 	path string
 }
 
-func (u *unixForwarder) Dial(_, _ string) (net.Conn, error) {
-	return net.Dial("unix", u.path)
+func (u *unixForwarder) Dial(network, address string) (net.Conn, error) {
+	return u.DialContext(context.Background(), network, address)
 }
 
-func dialViaNSProxy(sockPath, address string) (net.Conn, error) {
+func (u *unixForwarder) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	var d net.Dialer
+	return d.DialContext(ctx, "unix", u.path)
+}
+
+func dialViaNSProxy(ctx context.Context, sockPath, address string) (net.Conn, error) {
 	forward := &unixForwarder{path: sockPath}
 	dialer, err := proxy.SOCKS5("tcp", "unused", nil, forward)
 	if err != nil {
 		return nil, err
+	}
+	if cd, ok := dialer.(proxy.ContextDialer); ok {
+		return cd.DialContext(ctx, "tcp", address)
 	}
 	return dialer.Dial("tcp", address)
 }


### PR DESCRIPTION
## 개요

웹 콘솔(브라우저 ↔ VM SSH 릴레이)의 WebSocket 스택을 전면 개선합니다.

- 유지보수가 중단된 `golang.org/x/net/websocket`을 `github.com/coder/websocket`으로 교체
- 릴레이 코어를 전송 계층 독립 구조로 분리
- 출력 배칭·백프레셔·버퍼 풀링으로 대량 출력 시 성능/메모리 안정성 확보
- keepalive + 세션 수명 제한으로 유휴 상태의 죽은 연결·방치 세션 정리

## 변경 사항

### 1. WebSocket 라이브러리 교체 (`coder/websocket` v1.8.14)
- 핸드셰이크 전에 Origin을 직접 검증하고 실패 시 403 JSON 응답 (기존엔 라이브러리 콜백 의존)
- 클라이언트 입력 프레임 크기 제한 1MB (`SetReadLimit`)

### 2. 릴레이 구조 분리
- `bridgeWebConsole`(WebSocket 전용) → `relayConsole(client io.ReadWriteCloser, ...)`로 리팩토링.
  WebSocket은 `webSocketConsole` 어댑터로 감싸서 전달 — 릴레이 코어는 전송 방식을 모름
- 양방향 복사를 수동 루프 + done 채널 폴링에서 `io.Copy` 펌프 + context 취소로 단순화
- NS 프록시 dial / SSH 연결에 15초 타임아웃 추가 (`dialViaNSProxy`가 context를 받도록 변경)

### 3. 출력 배칭 + 백프레셔 + 버퍼 풀링
- SSH 출력을 8ms 간격 또는 64KB 도달 시 하나의 바이너리 프레임으로 묶어 전송 → 프레임 폭주 방지
- 출력 버퍼 1MB 상한. 가득 차면 `Write`가 블로킹되어 SSH 읽기 루프를 직접 늦춤
  (느린 클라이언트로 인한 무한 버퍼링 방지). WebSocket 쓰기 10초 타임아웃 초과 시 강제 종료
- `sync.Pool`로 플러시 버퍼 재사용 → 대량 출력 시 GC 부담 감소

### 4. keepalive + 세션 수명 제한 (`console_liveness.go`)

기존에는 유휴 상태에서 죽은 브라우저/VM을 감지할 방법이 없어 SSH 세션·고루틴·
authorized key 정리가 무기한 지연될 수 있었습니다. 30초 간격 단일 감시 루프가
아래를 한 번에 검사하고, 실패 시 원인(`context.WithCancelCause`)을 담아 릴레이를
종료합니다:

- **WS ping**: 브라우저는 프로토콜 ping에 자동 응답하므로 프론트엔드 수정 불필요
- **SSH keepalive**: `keepalive@openssh.com` 글로벌 요청 (OpenSSH `ServerAliveInterval`과 동일)
- **유휴 타임아웃 30분 / 절대 수명 12시간**: 입출력 활동 시각을 추적해 방치된 탭 정리

## 테스트

- [x] `go test ./internal/domain/access/ -race` 통과
- [x] liveness 판정(유휴/수명/프로브 실패), 활동 스탬핑, 감시 루프 취소,
      SSH 프로브(성공/실패/행), 실제 WebSocket 왕복 ping 테스트 추가
- [x] 기존 Origin 검증·핸들러 테스트는 변경된 시그니처에 맞게 수정 후 통과

## 참고

- 터미널 리사이즈(현재 PTY 24x80 고정)는 클라이언트가 크기 메시지를 보내야 하므로
  프론트엔드 작업과 함께 후속 PR에서 진행 예정