### PR TITLE
fix: 인증·DB·컴퓨트·게이트웨이 전반 성능 및 안정성 개선

### DIFF
--- a/.github/workflows/deploy-app-gateway.yml
+++ b/.github/workflows/deploy-app-gateway.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Run Tests
         run: go test ./cmd/app-gateway ./internal/infrastructure/database -v

--- a/.github/workflows/deploy-ns-proxy.yml
+++ b/.github/workflows/deploy-ns-proxy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Run Tests
         run: go test ./... -v

--- a/.github/workflows/deploy-ssh-gateway.yml
+++ b/.github/workflows/deploy-ssh-gateway.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Run Tests
         run: go test ./cmd/ssh-gateway ./internal/domain/access ./internal/infrastructure/database -v

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Run Tests
         run: go test ./... -v

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"errors"
 	"log"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/KHU-RETURN/rcp-server/internal/infrastructure/database"
 	"github.com/KHU-RETURN/rcp-server/internal/infrastructure/google"
@@ -96,7 +98,15 @@ func main() {
 	if port == "" {
 		port = "8080"
 	}
-	if err := r.Run(":" + port); err != nil {
+	// gin의 기본 서버는 타임아웃이 없어 Slowloris에 취약하다. ReadTimeout/WriteTimeout은
+	// 콘솔 websocket 연결이 장시간 유지돼야 해서 일부러 설정하지 않는다.
+	httpSrv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	if err := httpSrv.ListenAndServe(); err != nil {
 		log.Fatalf("HTTP 서버 시작 실패: %v", err)
 	}
 }
@@ -132,7 +142,7 @@ func resolveDBConfig(getenv func(string) string) (string, string) {
 	}
 	dsn := strings.TrimSpace(getenv("DB_DSN"))
 	if dsn == "" {
-		dsn = "file:rcp.db?cache=shared&_pragma=foreign_keys(1)"
+		dsn = "file:rcp.db?cache=shared&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)"
 	}
 	return driver, dsn
 }

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -35,7 +35,7 @@ func TestResolveDBDSNDefaultsToCanonicalSQLitePath(t *testing.T) {
 	if driver != "sqlite3" {
 		t.Fatalf("driver got %q", driver)
 	}
-	if dsn != "file:rcp.db?cache=shared&_pragma=foreign_keys(1)" {
+	if dsn != "file:rcp.db?cache=shared&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)" {
 		t.Fatalf("dsn got %q", dsn)
 	}
 }

--- a/cmd/app-gateway/config.go
+++ b/cmd/app-gateway/config.go
@@ -40,7 +40,7 @@ func LoadConfig(getenv func(string) string) (*Config, error) {
 	}
 	dbDSN := strings.TrimSpace(getenv("DB_DSN"))
 	if dbDSN == "" {
-		dbDSN = "file:rcp.db?mode=ro&cache=shared&_pragma=foreign_keys(1)"
+		dbDSN = "file:rcp.db?mode=ro&cache=shared&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)"
 	}
 	if err := validateGatewayDBDSN(dbDriver, dbDSN); err != nil {
 		return nil, err

--- a/cmd/app-gateway/config_test.go
+++ b/cmd/app-gateway/config_test.go
@@ -23,7 +23,7 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if cfg.DBDriver != "sqlite3" {
 		t.Fatalf("DBDriver got %q", cfg.DBDriver)
 	}
-	if cfg.DBDSN != "file:rcp.db?mode=ro&cache=shared&_pragma=foreign_keys(1)" {
+	if cfg.DBDSN != "file:rcp.db?mode=ro&cache=shared&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)" {
 		t.Fatalf("DBDSN got %q", cfg.DBDSN)
 	}
 	if cfg.ReadTimeout != 30*time.Second {

--- a/cmd/app-gateway/main.go
+++ b/cmd/app-gateway/main.go
@@ -52,7 +52,10 @@ func main() {
 		fatal("openstack compute client: %v", err)
 	}
 
-	app := NewServer(cfg, log, newRepo(db), resolver)
+	app, err := NewServer(cfg, log, newRepo(db), resolver)
+	if err != nil {
+		fatal("server build: %v", err)
+	}
 	httpSrv := &http.Server{
 		Addr:              cfg.Listen,
 		Handler:           app,

--- a/cmd/app-gateway/proxy.go
+++ b/cmd/app-gateway/proxy.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -12,12 +13,33 @@ import (
 	"golang.org/x/net/proxy"
 )
 
+// socks5HandshakeTimeout bounds the SOCKS5 CONNECT handshake when the caller's
+// context carries no deadline of its own.
+const socks5HandshakeTimeout = 15 * time.Second
+
 type unixForwarder struct {
 	path string
 }
 
-func (u *unixForwarder) Dial(_, _ string) (net.Conn, error) {
-	return net.Dial("unix", u.path)
+func (u *unixForwarder) Dial(network, address string) (net.Conn, error) {
+	return u.DialContext(context.Background(), network, address)
+}
+
+// DialContext dials the unix socket and holds a deadline over the connection
+// so the SOCKS5 handshake that immediately follows (performed by the
+// golang.org/x/net/proxy library right after this returns) can't stall
+// forever. The caller clears the deadline once the handshake succeeds.
+func (u *unixForwarder) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	conn, err := net.Dial("unix", u.path)
+	if err != nil {
+		return nil, err
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(socks5HandshakeTimeout)
+	}
+	_ = conn.SetDeadline(deadline)
+	return conn, nil
 }
 
 func transportViaNSProxy(sockPath string) (*http.Transport, error) {
@@ -25,6 +47,10 @@ func transportViaNSProxy(sockPath string) (*http.Transport, error) {
 	dialer, err := proxy.SOCKS5("tcp", "unused", nil, forward)
 	if err != nil {
 		return nil, err
+	}
+	ctxDialer, ok := dialer.(proxy.ContextDialer)
+	if !ok {
+		return nil, errors.New("socks5 dialer missing context support")
 	}
 
 	return &http.Transport{
@@ -36,7 +62,7 @@ func transportViaNSProxy(sockPath string) (*http.Transport, error) {
 			}
 			ch := make(chan result, 1)
 			go func() {
-				conn, err := dialer.Dial(network, address)
+				conn, err := ctxDialer.DialContext(ctx, network, address)
 				ch <- result{conn: conn, err: err}
 			}()
 			select {
@@ -50,6 +76,11 @@ func transportViaNSProxy(sockPath string) (*http.Transport, error) {
 				}()
 				return nil, ctx.Err()
 			case res := <-ch:
+				if res.conn != nil {
+					// Handshake succeeded; clear the deadline so it doesn't
+					// kill the long-lived proxied stream.
+					_ = res.conn.SetDeadline(time.Time{})
+				}
 				return res.conn, res.err
 			}
 		},

--- a/cmd/app-gateway/proxy.go
+++ b/cmd/app-gateway/proxy.go
@@ -41,6 +41,13 @@ func transportViaNSProxy(sockPath string) (*http.Transport, error) {
 			}()
 			select {
 			case <-ctx.Done():
+				// The dial goroutine may still complete; make sure an
+				// abandoned successful dial doesn't leak its connection.
+				go func() {
+					if res := <-ch; res.conn != nil {
+						_ = res.conn.Close()
+					}
+				}()
 				return nil, ctx.Err()
 			case res := <-ch:
 				return res.conn, res.err
@@ -54,13 +61,12 @@ func transportViaNSProxy(sockPath string) (*http.Transport, error) {
 	}, nil
 }
 
-func newReverseProxy(fixedIP string, targetPort int, sockPath string) (*httputil.ReverseProxy, error) {
+// newReverseProxy builds a per-request proxy around a shared transport. The
+// transport (and its idle-connection pool) is created once in NewServer;
+// only the target URL varies per request.
+func newReverseProxy(fixedIP string, targetPort int, transport http.RoundTripper) *httputil.ReverseProxy {
 	target := &url.URL{Scheme: "http", Host: net.JoinHostPort(fixedIP, strconv.Itoa(targetPort))}
-	transport, err := transportViaNSProxy(sockPath)
-	if err != nil {
-		return nil, err
-	}
-	rp := &httputil.ReverseProxy{
+	return &httputil.ReverseProxy{
 		Transport: transport,
 		Rewrite: func(req *httputil.ProxyRequest) {
 			req.SetURL(target)
@@ -68,5 +74,4 @@ func newReverseProxy(fixedIP string, targetPort int, sockPath string) (*httputil
 			req.SetXForwarded()
 		},
 	}
-	return rp, nil
 }

--- a/cmd/app-gateway/proxy_test.go
+++ b/cmd/app-gateway/proxy_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 func TestNewReverseProxyPreservesOriginalHost(t *testing.T) {
-	rp, err := newReverseProxy("10.0.0.8", 80, "/tmp/missing.sock")
+	tr, err := transportViaNSProxy("/tmp/missing.sock")
 	if err != nil {
-		t.Fatalf("newReverseProxy returned error: %v", err)
+		t.Fatalf("transportViaNSProxy returned error: %v", err)
 	}
+	rp := newReverseProxy("10.0.0.8", 80, tr)
 
 	req, err := http.NewRequest(http.MethodGet, "http://return.apps.khu-return.com/path?q=1", nil)
 	if err != nil {

--- a/cmd/app-gateway/resolver.go
+++ b/cmd/app-gateway/resolver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/KHU-RETURN/rcp-server/internal/infrastructure/openstack"
 	"github.com/gophercloud/gophercloud"
@@ -22,6 +23,11 @@ type gopherResolver struct {
 }
 
 func newGopherResolver(p *gophercloud.ProviderClient, fixedNetwork string) (*gopherResolver, error) {
+	// Without a timeout a hung OpenStack API blocks forever; the caller's
+	// context is also honored per call via computeWithContext.
+	if p.HTTPClient.Timeout <= 0 {
+		p.HTTPClient.Timeout = 15 * time.Second
+	}
 	c, err := goopenstack.NewComputeV2(p, gophercloud.EndpointOpts{Region: openstack.Region})
 	if err != nil {
 		return nil, err
@@ -29,12 +35,22 @@ func newGopherResolver(p *gophercloud.ProviderClient, fixedNetwork string) (*gop
 	return &gopherResolver{compute: c, fixedNetwork: strings.TrimSpace(fixedNetwork)}, nil
 }
 
-func (g *gopherResolver) ResolveFixedIPv4(_ context.Context, openstackID string) (string, error) {
-	srv, err := gccompute.Get(g.compute, openstackID).Extract()
+func (g *gopherResolver) ResolveFixedIPv4(ctx context.Context, openstackID string) (string, error) {
+	srv, err := gccompute.Get(g.computeWithContext(ctx), openstackID).Extract()
 	if err != nil {
 		return "", err
 	}
 	return fixedIPv4FromAddresses(srv.Addresses, g.fixedNetwork)
+}
+
+// computeWithContext returns a shallow copy of the compute client whose
+// provider carries ctx, so gophercloud requests respect caller deadlines.
+func (g *gopherResolver) computeWithContext(ctx context.Context) *gophercloud.ServiceClient {
+	provider := *g.compute.ProviderClient
+	provider.Context = ctx
+	client := *g.compute
+	client.ProviderClient = &provider
+	return &client
 }
 
 func fixedIPv4FromAddresses(addresses map[string]any, fixedNetwork string) (string, error) {

--- a/cmd/app-gateway/server.go
+++ b/cmd/app-gateway/server.go
@@ -7,26 +7,60 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
-const defaultAppTargetPort = 80
+const (
+	defaultAppTargetPort = 80
+	hostCacheTTL         = 30 * time.Second
+)
 
 var errNotFound = errors.New("not found")
 
+// backend is a resolved proxy target for a host.
+type backend struct {
+	ip          string
+	openstackID string
+}
+
+type hostCacheEntry struct {
+	backend backend
+	expires time.Time
+}
+
 type Server struct {
-	cfg      *Config
-	log      *slog.Logger
-	repo     appRepo
-	resolver fixedIPResolver
+	cfg       *Config
+	log       *slog.Logger
+	repo      appRepo
+	resolver  fixedIPResolver
+	transport http.RoundTripper
+
+	mu sync.Mutex
+	// hostCache maps host -> resolved backend with a TTL so the hot path
+	// skips the per-request DB lookup + OpenStack servers.Get.
+	// ponytail: no LRU/size cap — entries are bounded by the number of app
+	// mappings in the DB, which is tiny at this scale.
+	hostCache map[string]hostCacheEntry
 }
 
 type appRepo interface {
 	FindByHost(ctx context.Context, host string) (*AppMapping, error)
 }
 
-func NewServer(cfg *Config, log *slog.Logger, r appRepo, resolver fixedIPResolver) *Server {
-	return &Server{cfg: cfg, log: log, repo: r, resolver: resolver}
+func NewServer(cfg *Config, log *slog.Logger, r appRepo, resolver fixedIPResolver) (*Server, error) {
+	transport, err := transportViaNSProxy(cfg.NsProxySock)
+	if err != nil {
+		return nil, err
+	}
+	return &Server{
+		cfg:       cfg,
+		log:       log,
+		repo:      r,
+		resolver:  resolver,
+		transport: transport,
+		hostCache: make(map[string]hostCacheEntry),
+	}, nil
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -36,42 +70,58 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mapping, err := s.repo.FindByHost(r.Context(), host)
-	if err != nil {
-		if errors.Is(err, errNotFound) {
-			w.WriteHeader(http.StatusNotFound)
+	be, ok := s.cachedBackend(host)
+	if !ok {
+		mapping, err := s.repo.FindByHost(r.Context(), host)
+		if err != nil {
+			if errors.Is(err, errNotFound) {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			s.log.Error("app lookup failed", "host", host, "err", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
-		s.log.Error("app lookup failed", "host", host, "err", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
+
+		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+		defer cancel()
+		fixedIP, err := s.resolver.ResolveFixedIPv4(ctx, mapping.OpenstackID)
+		if err != nil {
+			s.log.Warn("fixed ip resolve failed", "host", host, "instance", mapping.OpenstackID, "err", err)
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		be = backend{ip: fixedIP, openstackID: mapping.OpenstackID}
+		s.storeBackend(host, be)
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
-	defer cancel()
-	fixedIP, err := s.resolver.ResolveFixedIPv4(ctx, mapping.OpenstackID)
-	if err != nil {
-		s.log.Warn("fixed ip resolve failed", "host", host, "instance", mapping.OpenstackID, "err", err)
-		http.Error(w, "bad gateway", http.StatusBadGateway)
-		return
-	}
-
-	rp, err := newReverseProxy(fixedIP, defaultAppTargetPort, s.cfg.NsProxySock)
-	if err != nil {
-		s.log.Error("proxy build failed", "host", host, "err", err)
-		http.Error(w, "bad gateway", http.StatusBadGateway)
-		return
-	}
+	rp := newReverseProxy(be.ip, defaultAppTargetPort, s.transport)
 	rp.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
 		s.log.Warn("proxy error",
 			"host", req.Host,
-			"instance", mapping.OpenstackID,
-			"target", net.JoinHostPort(fixedIP, "80"),
+			"instance", be.openstackID,
+			"target", net.JoinHostPort(be.ip, "80"),
 			"err", err,
 		)
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 	}
 	rp.ServeHTTP(w, r)
+}
+
+func (s *Server) cachedBackend(host string) (backend, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.hostCache[host]
+	if !ok || time.Now().After(e.expires) {
+		return backend{}, false
+	}
+	return e.backend, true
+}
+
+func (s *Server) storeBackend(host string, be backend) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hostCache[host] = hostCacheEntry{backend: be, expires: time.Now().Add(hostCacheTTL)}
 }
 
 func normalizeHost(host string) string {

--- a/cmd/app-gateway/server_test.go
+++ b/cmd/app-gateway/server_test.go
@@ -7,15 +7,18 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 type fakeRepo struct {
 	mapping *AppMapping
 	err     error
+	calls   int
 }
 
-func (f fakeRepo) FindByHost(context.Context, string) (*AppMapping, error) {
+func (f *fakeRepo) FindByHost(context.Context, string) (*AppMapping, error) {
+	f.calls++
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -26,31 +29,53 @@ func (f fakeRepo) FindByHost(context.Context, string) (*AppMapping, error) {
 }
 
 type fakeResolver struct {
-	ip  string
-	err error
+	ip    string
+	err   error
+	calls int
 }
 
-func (f fakeResolver) ResolveFixedIPv4(context.Context, string) (string, error) {
+func (f *fakeResolver) ResolveFixedIPv4(context.Context, string) (string, error) {
+	f.calls++
 	if f.err != nil {
 		return "", f.err
 	}
 	return f.ip, nil
 }
 
-func testServer(repo appRepo, resolver fixedIPResolver) *Server {
-	return NewServer(
+func testServer(t *testing.T, repo appRepo, resolver fixedIPResolver) *Server {
+	t.Helper()
+	srv, err := NewServer(
 		&Config{NsProxySock: "/tmp/missing.sock"},
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
 		repo,
 		resolver,
 	)
+	if err != nil {
+		t.Fatalf("NewServer returned error: %v", err)
+	}
+	return srv
+}
+
+// countingTransport counts round trips so tests can prove one shared
+// transport instance serves every request.
+type countingTransport struct {
+	calls int
+}
+
+func (c *countingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	c.calls++
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("ok")),
+		Header:     make(http.Header),
+	}, nil
 }
 
 func TestServerReturns404ForUnknownHost(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://missing.apps.khu-return.com/", nil)
 	rr := httptest.NewRecorder()
 
-	testServer(fakeRepo{}, fakeResolver{}).ServeHTTP(rr, req)
+	testServer(t, &fakeRepo{}, &fakeResolver{}).ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("status got %d", rr.Code)
@@ -61,7 +86,7 @@ func TestServerReturns500ForRepoError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://abc.apps.khu-return.com/", nil)
 	rr := httptest.NewRecorder()
 
-	testServer(fakeRepo{err: errors.New("db down")}, fakeResolver{}).ServeHTTP(rr, req)
+	testServer(t, &fakeRepo{err: errors.New("db down")}, &fakeResolver{}).ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("status got %d", rr.Code)
@@ -73,12 +98,65 @@ func TestServerReturns502ForResolverError(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	testServer(
-		fakeRepo{mapping: &AppMapping{Host: "abc.apps.khu-return.com", OpenstackID: "os-1"}},
-		fakeResolver{err: errors.New("no fixed ip")},
+		t,
+		&fakeRepo{mapping: &AppMapping{Host: "abc.apps.khu-return.com", OpenstackID: "os-1"}},
+		&fakeResolver{err: errors.New("no fixed ip")},
 	).ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusBadGateway {
 		t.Fatalf("status got %d", rr.Code)
+	}
+}
+
+func TestServerReusesTransportAcrossRequests(t *testing.T) {
+	repo := &fakeRepo{mapping: &AppMapping{Host: "abc.apps.khu-return.com", OpenstackID: "os-1"}}
+	resolver := &fakeResolver{ip: "10.0.0.8"}
+	srv := testServer(t, repo, resolver)
+
+	first := srv.transport
+	if first == nil {
+		t.Fatal("transport not built in NewServer")
+	}
+
+	ct := &countingTransport{}
+	srv.transport = ct
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "http://abc.apps.khu-return.com/", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d status got %d", i, rr.Code)
+		}
+	}
+	if srv.transport != ct {
+		t.Fatal("transport instance changed between requests")
+	}
+	if ct.calls != 2 {
+		t.Fatalf("shared transport served %d requests, want 2", ct.calls)
+	}
+}
+
+func TestServerCachesHostBackendResolution(t *testing.T) {
+	repo := &fakeRepo{mapping: &AppMapping{Host: "abc.apps.khu-return.com", OpenstackID: "os-1"}}
+	resolver := &fakeResolver{ip: "10.0.0.8"}
+	srv := testServer(t, repo, resolver)
+	srv.transport = &countingTransport{}
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "http://abc.apps.khu-return.com/", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d status got %d", i, rr.Code)
+		}
+	}
+
+	if repo.calls != 1 {
+		t.Fatalf("repo hit %d times, want 1 (cached)", repo.calls)
+	}
+	if resolver.calls != 1 {
+		t.Fatalf("resolver hit %d times, want 1 (cached)", resolver.calls)
 	}
 }
 

--- a/cmd/ssh-gateway/config.go
+++ b/cmd/ssh-gateway/config.go
@@ -9,6 +9,8 @@ import (
 	"github.com/KHU-RETURN/rcp-server/internal/utils"
 )
 
+const defaultMaxConns = 256
+
 type Config struct {
 	Listen             string        // outer SSH listen address, e.g. ":2222"
 	HostKeyPath        string        // ed25519 host key file (created on first boot)
@@ -20,6 +22,7 @@ type Config struct {
 	APIURLBase         string        // API origin used for internal ephemeral-key registration
 	NonceTTL           time.Duration // pending-session lifetime
 	MaxPendingSessions int           // pending OAuth sessions cap
+	MaxConns           int           // concurrent accepted SSH connections cap
 	FixedNetworkName   string        // optional OpenStack network name for fixed IP selection
 	VMUsers            []string      // inner SSH login users tried in order
 	DBDriver           string        // ent DB driver
@@ -84,7 +87,7 @@ func LoadConfig(getenv func(string) string) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		dbDSN = "file:" + dbPath + "?mode=ro&cache=shared&_pragma=foreign_keys(1)"
+		dbDSN = "file:" + dbPath + "?mode=ro&cache=shared&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)"
 	}
 	if err := validateGatewayDBDSN(dbDriver, dbDSN); err != nil {
 		return nil, err
@@ -100,6 +103,13 @@ func LoadConfig(getenv func(string) string) (*Config, error) {
 	}
 	if maxPending <= 0 {
 		return nil, fmt.Errorf("RCP_SSH_GW_MAX_PENDING_SESSIONS: must be > 0, got %d", maxPending)
+	}
+	maxConns, err := utils.EnvInt(getenv, "RCP_SSH_GW_MAX_CONNS", defaultMaxConns)
+	if err != nil {
+		return nil, err
+	}
+	if maxConns <= 0 {
+		return nil, fmt.Errorf("RCP_SSH_GW_MAX_CONNS: must be > 0, got %d", maxConns)
 	}
 	fixedNetwork := strings.TrimSpace(getenv("RCP_SSH_GW_FIXED_NETWORK"))
 	vmUsers := parseVMUsers(getenv)
@@ -120,6 +130,7 @@ func LoadConfig(getenv func(string) string) (*Config, error) {
 		APIURLBase:         apiURL,
 		NonceTTL:           ttl,
 		MaxPendingSessions: maxPending,
+		MaxConns:           maxConns,
 		FixedNetworkName:   fixedNetwork,
 		VMUsers:            vmUsers,
 		DBDriver:           dbDriver,

--- a/cmd/ssh-gateway/config_test.go
+++ b/cmd/ssh-gateway/config_test.go
@@ -41,7 +41,7 @@ func TestLoadConfig_AllDefaultsExceptRequired(t *testing.T) {
 	if cfg.DBDriver != "sqlite3" {
 		t.Errorf("DBDriver default: got %q", cfg.DBDriver)
 	}
-	if cfg.DBDSN != "file:/var/lib/rcp/rcp.db?mode=ro&cache=shared&_pragma=foreign_keys(1)" {
+	if cfg.DBDSN != "file:/var/lib/rcp/rcp.db?mode=ro&cache=shared&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)" {
 		t.Errorf("DBDSN fallback: got %q", cfg.DBDSN)
 	}
 	if cfg.KnownHostsPath != "/etc/rcp/ssh-gateway/known_hosts" {
@@ -49,6 +49,9 @@ func TestLoadConfig_AllDefaultsExceptRequired(t *testing.T) {
 	}
 	if cfg.MaxPendingSessions != defaultMaxPendingSessions {
 		t.Errorf("MaxPendingSessions default: got %d", cfg.MaxPendingSessions)
+	}
+	if cfg.MaxConns != defaultMaxConns {
+		t.Errorf("MaxConns default: got %d", cfg.MaxConns)
 	}
 	if cfg.FixedNetworkName != "" {
 		t.Errorf("FixedNetworkName default: got %q", cfg.FixedNetworkName)
@@ -158,6 +161,19 @@ func TestLoadConfig_MaxPendingPositive(t *testing.T) {
 	}))
 	if err == nil {
 		t.Fatalf("expected MAX_PENDING_SESSIONS > 0 error")
+	}
+}
+
+func TestLoadConfig_MaxConnsPositive(t *testing.T) {
+	_, err := LoadConfig(envFromMap(map[string]string{
+		"RCP_SSH_GW_NOTIFY_SECRET": "x",
+		"RCP_SSH_GW_AUTH_URL_BASE": "x",
+		"RCP_SSH_GW_API_URL_BASE":  "api-x",
+		"RCP_SSH_GW_DB_PATH":       "/x",
+		"RCP_SSH_GW_MAX_CONNS":     "0",
+	}))
+	if err == nil {
+		t.Fatalf("expected MAX_CONNS > 0 error")
 	}
 }
 

--- a/cmd/ssh-gateway/main.go
+++ b/cmd/ssh-gateway/main.go
@@ -155,6 +155,11 @@ type gopherResolver struct {
 }
 
 func newGopherResolver(p *gophercloud.ProviderClient, fixedNetwork string) (*gopherResolver, error) {
+	// Without a timeout a hung OpenStack API blocks forever; the caller's
+	// context is also honored per call via computeWithContext.
+	if p.HTTPClient.Timeout <= 0 {
+		p.HTTPClient.Timeout = 15 * time.Second
+	}
 	c, err := goopenstack.NewComputeV2(p, gophercloud.EndpointOpts{Region: "RegionOne"})
 	if err != nil {
 		return nil, err
@@ -162,8 +167,8 @@ func newGopherResolver(p *gophercloud.ProviderClient, fixedNetwork string) (*gop
 	return &gopherResolver{compute: c, fixedNetwork: strings.TrimSpace(fixedNetwork)}, nil
 }
 
-func (g *gopherResolver) ResolveVM(_ context.Context, openstackID string) (VMRuntime, error) {
-	srv, err := gccompute.Get(g.compute, openstackID).Extract()
+func (g *gopherResolver) ResolveVM(ctx context.Context, openstackID string) (VMRuntime, error) {
+	srv, err := gccompute.Get(g.computeWithContext(ctx), openstackID).Extract()
 	if err != nil {
 		return VMRuntime{}, err
 	}
@@ -172,6 +177,16 @@ func (g *gopherResolver) ResolveVM(_ context.Context, openstackID string) (VMRun
 		return VMRuntime{Status: srv.Status}, nil
 	}
 	return VMRuntime{Status: srv.Status, FixedIPv4: fixedIP}, nil
+}
+
+// computeWithContext returns a shallow copy of the compute client whose
+// provider carries ctx, so gophercloud requests respect caller deadlines.
+func (g *gopherResolver) computeWithContext(ctx context.Context) *gophercloud.ServiceClient {
+	provider := *g.compute.ProviderClient
+	provider.Context = ctx
+	client := *g.compute
+	client.ProviderClient = &provider
+	return &client
 }
 
 func fixedIPv4FromAddresses(addresses map[string]any, fixedNetwork string) (string, error) {

--- a/cmd/ssh-gateway/menu.go
+++ b/cmd/ssh-gateway/menu.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 var ErrSelectionInvalid = errors.New("invalid selection")
@@ -45,21 +46,30 @@ func FindByName(vms []VM, name string) (VM, bool) {
 	return VM{}, false
 }
 
+// applyRuntimeInfo resolves each VM's live status/address concurrently so a
+// user with N VMs pays one round-trip of latency instead of N sequential ones
+// under the shared timeout.
 func applyRuntimeInfo(vms []VM, resolve func(VM) (VMRuntime, error)) []VM {
-	out := make([]VM, 0, len(vms))
-	for _, vm := range vms {
-		runtime, err := resolve(vm)
-		if err != nil {
-			vm.Status = "UNKNOWN"
-			vm.FixedIPv4 = ""
-			out = append(out, vm)
-			continue
-		}
-		if strings.TrimSpace(runtime.Status) != "" {
-			vm.Status = runtime.Status
-		}
-		vm.FixedIPv4 = runtime.FixedIPv4
-		out = append(out, vm)
+	out := make([]VM, len(vms))
+	var wg sync.WaitGroup
+	for i, vm := range vms {
+		wg.Add(1)
+		go func(i int, vm VM) {
+			defer wg.Done()
+			runtime, err := resolve(vm)
+			if err != nil {
+				vm.Status = "UNKNOWN"
+				vm.FixedIPv4 = ""
+				out[i] = vm
+				return
+			}
+			if strings.TrimSpace(runtime.Status) != "" {
+				vm.Status = runtime.Status
+			}
+			vm.FixedIPv4 = runtime.FixedIPv4
+			out[i] = vm
+		}(i, vm)
 	}
+	wg.Wait()
 	return out
 }

--- a/cmd/ssh-gateway/relay.go
+++ b/cmd/ssh-gateway/relay.go
@@ -18,6 +18,10 @@ import (
 
 const copyDrainTimeout = time.Second
 
+// socks5HandshakeTimeout bounds the SOCKS5 CONNECT handshake when the
+// caller's context carries no deadline of its own.
+const socks5HandshakeTimeout = 15 * time.Second
+
 // vmAddressResolver returns the dial-target IPv4 for an openstack_id. The PoC
 // implementation lives in main.go and uses gophercloud; tests can stub this.
 type vmAddressResolver interface {
@@ -47,7 +51,13 @@ func newNsProxyDialer(sockPath string, timeout time.Duration) (*nsProxyDialer, e
 // Dial opens a TCP-equivalent connection to host:port via the ns-proxy SOCKS5
 // server reachable on the local Unix socket.
 func (d *nsProxyDialer) Dial(ctx context.Context, host string, port int) (net.Conn, error) {
-	return d.socks.DialContext(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := d.socks.DialContext(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	if conn != nil {
+		// Handshake succeeded; clear the deadline set in unixDialer.DialContext
+		// so it doesn't kill the long-lived proxied stream.
+		_ = conn.SetDeadline(time.Time{})
+	}
+	return conn, err
 }
 
 // unixDialer satisfies proxy.Dialer/proxy.ContextDialer by always dialing a
@@ -69,7 +79,19 @@ func (u *unixDialer) DialContext(ctx context.Context, _, _ string) (net.Conn, er
 		defer cancel()
 	}
 	var d net.Dialer
-	return d.DialContext(dctx, "unix", u.path)
+	conn, err := d.DialContext(dctx, "unix", u.path)
+	if err != nil {
+		return nil, err
+	}
+	// Hold a deadline over the conn until the SOCKS5 handshake that follows
+	// (performed by the caller right after this returns) completes;
+	// nsProxyDialer.Dial clears it once the handshake succeeds.
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(socks5HandshakeTimeout)
+	}
+	_ = conn.SetDeadline(deadline)
+	return conn, nil
 }
 
 // dialInnerSSH performs the inner SSH handshake to the VM using an ephemeral

--- a/cmd/ssh-gateway/server.go
+++ b/cmd/ssh-gateway/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/KHU-RETURN/rcp-server/internal/domain/access"
@@ -27,6 +28,11 @@ type Server struct {
 	keyClient ephemeralKeyRegistrar
 	sshConfig *ssh.ServerConfig
 	hostKeyCB ssh.HostKeyCallback
+
+	sem chan struct{} // cfg.MaxConns 크기의 동시 접속 semaphore
+
+	activeConns int64 // sync/atomic으로만 접근
+	deniedConns int64
 }
 
 type ephemeralKeyRegistrar interface {
@@ -58,6 +64,7 @@ func NewServer(cfg *Config, log *slog.Logger, store *sessionStore, r *repo, reso
 		keyClient: newEphemeralKeyClient(cfg.APIURLBase, []byte(cfg.NotifySecret)),
 		sshConfig: sc,
 		hostKeyCB: hostKeyCB,
+		sem:       make(chan struct{}, cfg.MaxConns),
 	}, nil
 }
 
@@ -68,21 +75,49 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 		<-ctx.Done()
 		_ = ln.Close()
 	}()
+	var tempDelay time.Duration
 	for {
 		c, err := ln.Accept()
 		if err != nil {
 			if errors.Is(err, net.ErrClosed) {
 				return nil
 			}
-			s.log.Warn("accept", "err", err)
+			if tempDelay == 0 {
+				tempDelay = 10 * time.Millisecond
+			} else {
+				tempDelay *= 2
+			}
+			if tempDelay > time.Second {
+				tempDelay = time.Second
+			}
+			s.log.Warn("accept transient error, retrying", "err", err, "delay", tempDelay)
+			time.Sleep(tempDelay)
 			continue
 		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			s.handle(ctx, c)
-		}()
+		tempDelay = 0
+
+		select {
+		case s.sem <- struct{}{}:
+			atomic.AddInt64(&s.activeConns, 1)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer atomic.AddInt64(&s.activeConns, -1)
+				defer func() { <-s.sem }()
+				s.handle(ctx, c)
+			}()
+		default:
+			// 슬롯 만석 — SSH 핸드셰이크 전에 raw TCP를 끊는다.
+			atomic.AddInt64(&s.deniedConns, 1)
+			s.log.Warn("rejected: max conns reached")
+			_ = c.Close()
+		}
 	}
+}
+
+// Stats reports current concurrency for tests/observability.
+func (s *Server) Stats() (active, denied int64) {
+	return atomic.LoadInt64(&s.activeConns), atomic.LoadInt64(&s.deniedConns)
 }
 
 func (s *Server) handle(ctx context.Context, raw net.Conn) {

--- a/cmd/ssh-gateway/server.go
+++ b/cmd/ssh-gateway/server.go
@@ -178,10 +178,12 @@ func (s *Server) handleSession(ctx context.Context, sshConn *ssh.ServerConn, ch 
 	vms, err := s.repo.ListInstancesByEmail(ctx, email)
 	if err != nil {
 		_, _ = fmt.Fprintf(ch, "lookup failed: %v\r\n", err)
+		drainRequests(reqs)
 		return
 	}
 	if len(vms) == 0 {
 		_, _ = fmt.Fprintf(ch, "No instances. Create one at %s\r\n", s.cfg.AuthURLBase)
+		drainRequests(reqs)
 		return
 	}
 
@@ -198,6 +200,7 @@ func (s *Server) handleSession(ctx context.Context, sshConn *ssh.ServerConn, ch 
 		v, ok := FindByName(vms, strings.TrimSpace(execCmd))
 		if !ok {
 			_, _ = fmt.Fprintf(ch, "VM %q not found among your instances.\r\n", execCmd)
+			drainRequests(reqs)
 			return
 		}
 		target = v
@@ -206,6 +209,7 @@ func (s *Server) handleSession(ctx context.Context, sshConn *ssh.ServerConn, ch 
 	default:
 		v, ok := promptForVM(ch, vms)
 		if !ok {
+			drainRequests(reqs)
 			return
 		}
 		target = v
@@ -214,21 +218,39 @@ func (s *Server) handleSession(ctx context.Context, sshConn *ssh.ServerConn, ch 
 	ip := strings.TrimSpace(target.FixedIPv4)
 	if ip == "" {
 		_, _ = fmt.Fprintf(ch, "VM unreachable: no fixed IPv4 address for %s\r\n", target.Name)
+		drainRequests(reqs)
 		return
 	}
 
 	inner, keyReq, err := s.dialVMWithEphemeralKey(ctx, target, ip)
 	if err != nil {
 		_, _ = fmt.Fprintf(ch, "VM auth failed: %v\r\n", err)
+		drainRequests(reqs)
 		return
 	}
 	defer func() { _ = inner.Close() }()
 	defer s.deleteEphemeralKey(keyReq)
 
 	if err := pipeSession(s.log, ch, reqs, inner, pty, func() { _ = sshConn.Close() }); err != nil {
+		// pipeSession only errors before it starts forwarding reqs, so the
+		// queue still needs a consumer.
+		drainRequests(reqs)
 		s.log.Info("pipe ended", "err", err)
 		return
 	}
+}
+
+// drainRequests keeps servicing a session's channel-request queue after an
+// early exit. Without a reader, a client that sends further channel requests
+// wedges its own connection mux until the channel fully closes.
+func drainRequests(reqs <-chan *ssh.Request) {
+	go func() {
+		for req := range reqs {
+			if req.WantReply {
+				_ = req.Reply(false, nil)
+			}
+		}
+	}()
 }
 
 func (s *Server) dialVMWithEphemeralKey(ctx context.Context, target VM, ip string) (*ssh.Client, access.EphemeralAuthorizedKeyRequest, error) {

--- a/cmd/ssh-gateway/server_test.go
+++ b/cmd/ssh-gateway/server_test.go
@@ -2,8 +2,18 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
 	"io"
+	"log/slog"
+	"net"
+	"os"
 	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
 )
 
 type scriptedReadWriter struct {
@@ -50,5 +60,92 @@ func TestReadLineEchoesBackspace(t *testing.T) {
 	}
 	if rw.out.String() != "12\b \b3\r\n" {
 		t.Fatalf("echo got %q", rw.out.String())
+	}
+}
+
+// newTestSSHGatewayServer builds a Server with just enough state for Serve's
+// accept loop; handle() will block on the SSH handshake (never completing it
+// in these tests) rather than error out immediately, which is enough to hold
+// a semaphore slot open.
+func newTestSSHGatewayServer(t *testing.T, maxConns int) *Server {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate host key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	sc := &ssh.ServerConfig{
+		// A configured auth method is required or NewServerConn rejects the
+		// conn before any network I/O; the fake client below never speaks
+		// the protocol, so this callback is never actually invoked.
+		PasswordCallback: func(conn ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
+			return nil, errors.New("unused")
+		},
+	}
+	sc.AddHostKey(signer)
+
+	return &Server{
+		cfg:       &Config{NonceTTL: 5 * time.Minute},
+		log:       slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		sshConfig: sc,
+		sem:       make(chan struct{}, maxConns),
+	}
+}
+
+func waitSSHGatewayActiveConns(t *testing.T, srv *Server, n int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		active, _ := srv.Stats()
+		if active >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	active, _ := srv.Stats()
+	t.Fatalf("activeConns = %d after 2s; want >= %d", active, n)
+}
+
+// sem이 가득 차면 Serve는 SSH 핸드셰이크 전에 raw TCP를 끊고 deniedConns를 증가.
+func TestServer_RejectsAtMaxConns(t *testing.T) {
+	srv := newTestSSHGatewayServer(t, 1)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = srv.Serve(ctx, ln) }()
+
+	// First connection: don't speak SSH, just hold the slot open.
+	conn1, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("first dial: %v", err)
+	}
+	defer func() { _ = conn1.Close() }()
+
+	waitSSHGatewayActiveConns(t, srv, 1)
+
+	// Second connection must be closed immediately — sem is full.
+	conn2, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("second dial: %v", err)
+	}
+	defer func() { _ = conn2.Close() }()
+
+	_ = conn2.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 1)
+	if _, err := conn2.Read(buf); err == nil {
+		t.Fatal("expected second connection to be closed by server, got data")
+	}
+
+	if _, denied := srv.Stats(); denied < 1 {
+		t.Errorf("deniedConns = %d; want >= 1", denied)
 	}
 }

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -52,6 +52,13 @@ var (
 				OnDelete:   schema.NoAction,
 			},
 		},
+		Indexes: []*schema.Index{
+			{
+				Name:    "container_name_user_containers",
+				Unique:  true,
+				Columns: []*schema.Column{ContainersColumns[2], ContainersColumns[5]},
+			},
+		},
 	}
 	// InstancesColumns holds the columns for the "instances" table.
 	InstancesColumns = []*schema.Column{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/KHU-RETURN/rcp-server
 
-go 1.26.4
+go 1.26.5
 
 require (
 	entgo.io/ent v0.14.6
@@ -58,7 +58,7 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
@@ -17,4 +19,16 @@ func OwnerID(c *gin.Context) (uuid.UUID, bool) {
 		return uuid.UUID{}, false
 	}
 	return u.ID, true
+}
+
+// MustOwnerID returns the authenticated owner ID, or aborts with 401 and
+// reports false. AuthRequired guarantees the user is set, so the false path
+// only fires on misconfiguration (a protected route without the middleware).
+func MustOwnerID(c *gin.Context) (uuid.UUID, bool) {
+	id, ok := OwnerID(c)
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, ErrorResponse{Error: "unauthorized"})
+		return uuid.UUID{}, false
+	}
+	return id, true
 }

--- a/internal/domain/access/service.go
+++ b/internal/domain/access/service.go
@@ -142,10 +142,9 @@ func (s *Service) DeleteKeyPair(ctx context.Context, ownerID uuid.UUID, name str
 		return ErrKeyPairNotFound
 	}
 
-	if err := s.client.DeleteKeyPair(name); err != nil {
-		if isNotFoundError(err) {
-			return ErrKeyPairNotFound
-		}
+	// OpenStack에 이미 없는 키(외부 삭제/이전 삭제의 DB 실패 잔재)는 성공으로
+	// 취급해 DB 정리까지 진행한다 — 아니면 그 행은 영원히 지울 수 없다.
+	if err := s.client.DeleteKeyPair(name); err != nil && !isNotFoundError(err) {
 		return fmt.Errorf("%w: %v", ErrKeyPairDeleteFailed, err)
 	}
 

--- a/internal/domain/access/service.go
+++ b/internal/domain/access/service.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -90,6 +91,10 @@ func (s *Service) CreateKeyPair(ctx context.Context, ownerID uuid.UUID, req Crea
 	}
 
 	if err := s.repo.SaveKeyPair(ctx, ownerID, kp); err != nil {
+		// 소유권 기록 실패 시 방금 만든 키페어를 회수해 고아 키페어를 막는다.
+		if delErr := s.client.DeleteKeyPair(kp.Name); delErr != nil {
+			log.Printf("CRITICAL: orphaned keypair %s: DB save failed (%v) and cleanup failed (%v)", kp.Name, err, delErr)
+		}
 		return nil, fmt.Errorf("%w: %v", ErrKeyPairOperationFailed, err)
 	}
 

--- a/internal/domain/access/service_test.go
+++ b/internal/domain/access/service_test.go
@@ -398,6 +398,43 @@ func TestServiceEphemeralAuthorizedKey(t *testing.T) {
 	}
 }
 
+func TestServiceDeleteKeyPair(t *testing.T) {
+	ctx := context.Background()
+	found := func(context.Context, uuid.UUID, string) (*KeyPair, error) {
+		return &KeyPair{Name: "k"}, nil
+	}
+
+	t.Run("deletes DB row even when OpenStack key is already gone", func(t *testing.T) {
+		dbDeleted := false
+		svc := NewService(
+			&fakeClient{deleteKeyPairFn: func(string) error { return newStatusErr(http.StatusNotFound) }},
+			&fakeRepo{
+				findByNameFn: found,
+				deleteByNameFn: func(context.Context, uuid.UUID, string) error {
+					dbDeleted = true
+					return nil
+				},
+			},
+		)
+		if err := svc.DeleteKeyPair(ctx, testOwnerID, "k"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !dbDeleted {
+			t.Fatal("expected DB row to be deleted")
+		}
+	})
+
+	t.Run("propagates non-404 OpenStack delete failure", func(t *testing.T) {
+		svc := NewService(
+			&fakeClient{deleteKeyPairFn: func(string) error { return newStatusErr(http.StatusInternalServerError) }},
+			&fakeRepo{findByNameFn: found},
+		)
+		if err := svc.DeleteKeyPair(ctx, testOwnerID, "k"); !errors.Is(err, ErrKeyPairDeleteFailed) {
+			t.Fatalf("expected ErrKeyPairDeleteFailed, got %v", err)
+		}
+	})
+}
+
 func consoleTokenFromURL(t *testing.T, rawURL string) string {
 	t.Helper()
 

--- a/internal/domain/access/service_test.go
+++ b/internal/domain/access/service_test.go
@@ -232,6 +232,60 @@ func TestServiceCreateKeyPair(t *testing.T) {
 		}
 	})
 
+	t.Run("deletes just-created openstack keypair when DB save fails", func(t *testing.T) {
+		deletedName := ""
+		osClient := &fakeClient{
+			createKeyPairFn: func(name, publicKey string) (*KeyPair, error) {
+				return &KeyPair{Name: name, Fingerprint: "fingerprint", PublicKey: publicKey}, nil
+			},
+			deleteKeyPairFn: func(name string) error {
+				deletedName = name
+				return nil
+			},
+		}
+		repo := &fakeRepo{
+			saveKeyPairFn: func(_ context.Context, _ uuid.UUID, _ *KeyPair) error {
+				return errors.New("db save error")
+			},
+		}
+
+		svc := NewService(osClient, repo)
+		_, err := svc.CreateKeyPair(ctx, testOwnerID, CreateKeyPairRequest{Name: "key", PublicKey: testPublicKey})
+		if !errors.Is(err, ErrKeyPairOperationFailed) {
+			t.Fatalf("expected ErrKeyPairOperationFailed, got %v", err)
+		}
+		if deletedName != "key" {
+			t.Fatalf("expected compensating delete of %q, got %q", "key", deletedName)
+		}
+	})
+
+	t.Run("returns original save error even when compensating delete fails", func(t *testing.T) {
+		deleteCalled := false
+		osClient := &fakeClient{
+			createKeyPairFn: func(name, publicKey string) (*KeyPair, error) {
+				return &KeyPair{Name: name, Fingerprint: "fingerprint", PublicKey: publicKey}, nil
+			},
+			deleteKeyPairFn: func(name string) error {
+				deleteCalled = true
+				return errors.New("cleanup error")
+			},
+		}
+		repo := &fakeRepo{
+			saveKeyPairFn: func(_ context.Context, _ uuid.UUID, _ *KeyPair) error {
+				return errors.New("db save error")
+			},
+		}
+
+		svc := NewService(osClient, repo)
+		_, err := svc.CreateKeyPair(ctx, testOwnerID, CreateKeyPairRequest{Name: "key", PublicKey: testPublicKey})
+		if !errors.Is(err, ErrKeyPairOperationFailed) {
+			t.Fatalf("expected ErrKeyPairOperationFailed, got %v", err)
+		}
+		if !deleteCalled {
+			t.Fatal("expected compensating delete to be attempted")
+		}
+	})
+
 	t.Run("normalizes generic openstack errors as internal operation error", func(t *testing.T) {
 		osClient := &fakeClient{
 			createKeyPairFn: func(name, publicKey string) (*KeyPair, error) {

--- a/internal/domain/admin/handler_test.go
+++ b/internal/domain/admin/handler_test.go
@@ -410,6 +410,31 @@ func TestServiceOverlaysLiveInstanceStatus(t *testing.T) {
 	}
 }
 
+func TestServiceSummaryCountsLiveStatuses(t *testing.T) {
+	ctx := context.Background()
+	client := newAdminTestClient(t, "admin-summary-live")
+	student := createTestUser(t, client, "student@return.dev", "student")
+
+	// DB statuses are stale ("BUILD"); vm-gone is absent from live data.
+	createTestInstance(t, client, student, "vm-live", "BUILD")
+	createTestInstance(t, client, student, "vm-gone", "BUILD")
+
+	svc := NewService(NewRepository(client), nil, fakeInstanceStatusSource{
+		statuses: map[string]string{"vm-live": "ACTIVE"},
+	})
+
+	res, err := svc.Summary(ctx)
+	if err != nil {
+		t.Fatalf("Summary: %v", err)
+	}
+	if res.Users != 1 || res.Instances != 2 {
+		t.Fatalf("unexpected summary counts: %+v", res)
+	}
+	if res.StatusCounts["ACTIVE"] != 1 || res.StatusCounts["BUILD"] != 1 {
+		t.Fatalf("expected live status counts with DB fallback, got %+v", res.StatusCounts)
+	}
+}
+
 func TestServiceFallsBackToDBStatusWhenLiveFetchFails(t *testing.T) {
 	ctx := context.Background()
 	client := newAdminTestClient(t, "admin-live-status-error")

--- a/internal/domain/admin/instance_status.go
+++ b/internal/domain/admin/instance_status.go
@@ -2,6 +2,8 @@ package admin
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 
@@ -13,10 +15,24 @@ type instanceStatusSource interface {
 	InstanceStatus(ctx context.Context, id string) (string, error)
 }
 
+// computeStatusClient is the subset of the compute client used to read live statuses.
+type computeStatusClient interface {
+	FetchInstances() ([]compute.Server, error)
+	FetchInstance(id string) (*compute.Server, error)
+}
+
+// statusCacheTTL — every admin list request would otherwise list all servers
+// in the project, so keep the ID→status map briefly cached.
+const statusCacheTTL = 15 * time.Second
+
 // liveInstanceStatusSource reuses the compute client so the admin views read the
 // same live OpenStack status as the user-facing compute views.
 type liveInstanceStatusSource struct {
-	client *compute.Client
+	client computeStatusClient
+
+	mu     sync.Mutex
+	cache  map[string]string
+	expire time.Time
 }
 
 func NewLiveInstanceStatusSource(provider *gophercloud.ProviderClient) instanceStatusSource {
@@ -24,6 +40,11 @@ func NewLiveInstanceStatusSource(provider *gophercloud.ProviderClient) instanceS
 }
 
 func (s *liveInstanceStatusSource) InstanceStatuses(context.Context) (map[string]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if time.Now().Before(s.expire) {
+		return s.cache, nil
+	}
 	servers, err := s.client.FetchInstances()
 	if err != nil {
 		return nil, err
@@ -32,6 +53,8 @@ func (s *liveInstanceStatusSource) InstanceStatuses(context.Context) (map[string
 	for _, srv := range servers {
 		statuses[srv.ID] = srv.Status
 	}
+	s.cache = statuses
+	s.expire = time.Now().Add(statusCacheTTL)
 	return statuses, nil
 }
 

--- a/internal/domain/admin/instance_status_test.go
+++ b/internal/domain/admin/instance_status_test.go
@@ -1,0 +1,52 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KHU-RETURN/rcp-server/internal/domain/compute"
+)
+
+type fakeComputeStatusClient struct {
+	servers    []compute.Server
+	fetchCalls int
+}
+
+func (f *fakeComputeStatusClient) FetchInstances() ([]compute.Server, error) {
+	f.fetchCalls++
+	return f.servers, nil
+}
+
+func (f *fakeComputeStatusClient) FetchInstance(string) (*compute.Server, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestLiveInstanceStatusSourceCachesStatuses(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeComputeStatusClient{servers: []compute.Server{{ID: "vm-1", Status: "ACTIVE"}}}
+	src := &liveInstanceStatusSource{client: fake}
+
+	for i := 0; i < 3; i++ {
+		statuses, err := src.InstanceStatuses(ctx)
+		if err != nil {
+			t.Fatalf("InstanceStatuses: %v", err)
+		}
+		if statuses["vm-1"] != "ACTIVE" {
+			t.Fatalf("unexpected statuses: %+v", statuses)
+		}
+	}
+	if fake.fetchCalls != 1 {
+		t.Fatalf("expected 1 fetch while cached, got %d", fake.fetchCalls)
+	}
+
+	// After the TTL expires the source must hit the client again.
+	src.expire = time.Now().Add(-time.Second)
+	if _, err := src.InstanceStatuses(ctx); err != nil {
+		t.Fatalf("InstanceStatuses after expiry: %v", err)
+	}
+	if fake.fetchCalls != 2 {
+		t.Fatalf("expected refresh after expiry, got %d fetches", fake.fetchCalls)
+	}
+}

--- a/internal/domain/admin/repository.go
+++ b/internal/domain/admin/repository.go
@@ -2,7 +2,7 @@ package admin
 
 import (
 	"context"
-	"strings"
+	"sync"
 
 	"entgo.io/ent/dialect/sql"
 	"github.com/KHU-RETURN/rcp-server/ent"
@@ -22,44 +22,60 @@ func NewRepository(client *ent.Client) *Repository {
 	return &Repository{client: client}
 }
 
-func (r *Repository) Summary(ctx context.Context) (SummaryResponse, error) {
-	users, err := r.client.User.Query().Count(ctx)
-	if err != nil {
-		return SummaryResponse{}, err
-	}
-	instances, err := r.client.Instance.Query().Count(ctx)
-	if err != nil {
-		return SummaryResponse{}, err
-	}
-	containers, err := r.client.Container.Query().Count(ctx)
-	if err != nil {
-		return SummaryResponse{}, err
-	}
-	keypairs, err := r.client.KeyPair.Query().Count(ctx)
-	if err != nil {
-		return SummaryResponse{}, err
-	}
-	rows, err := r.client.Instance.Query().All(ctx)
-	if err != nil {
-		return SummaryResponse{}, err
-	}
+// instanceStatusRow is a lightweight id/status projection used by the summary.
+type instanceStatusRow struct {
+	ID     string
+	Status string
+}
 
-	statusCounts := make(map[string]int)
-	for _, row := range rows {
-		status := strings.ToUpper(strings.TrimSpace(row.Status))
-		if status == "" {
-			status = "UNKNOWN"
+// summaryCounts holds raw resource counts plus instance id/status pairs so the
+// service can overlay live OpenStack statuses before building the response.
+type summaryCounts struct {
+	Users      int
+	Containers int
+	Keypairs   int
+	Instances  []instanceStatusRow
+}
+
+func (r *Repository) SummaryCounts(ctx context.Context) (summaryCounts, error) {
+	var (
+		counts summaryCounts
+		rows   []*ent.Instance
+		errs   [4]error
+		wg     sync.WaitGroup
+	)
+	wg.Add(4)
+	go func() {
+		defer wg.Done()
+		counts.Users, errs[0] = r.client.User.Query().Count(ctx)
+	}()
+	go func() {
+		defer wg.Done()
+		counts.Containers, errs[1] = r.client.Container.Query().Count(ctx)
+	}()
+	go func() {
+		defer wg.Done()
+		counts.Keypairs, errs[2] = r.client.KeyPair.Query().Count(ctx)
+	}()
+	go func() {
+		defer wg.Done()
+		// Only id/status pairs are needed; skip fetching full rows.
+		rows, errs[3] = r.client.Instance.Query().
+			Select(instance.FieldOpenstackID, instance.FieldStatus).
+			All(ctx)
+	}()
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return summaryCounts{}, err
 		}
-		statusCounts[status]++
 	}
 
-	return SummaryResponse{
-		Users:        users,
-		Instances:    instances,
-		Containers:   containers,
-		Keypairs:     keypairs,
-		StatusCounts: statusCounts,
-	}, nil
+	counts.Instances = make([]instanceStatusRow, 0, len(rows))
+	for _, row := range rows {
+		counts.Instances = append(counts.Instances, instanceStatusRow{ID: row.OpenstackID, Status: row.Status})
+	}
+	return counts, nil
 }
 
 func (r *Repository) Users(ctx context.Context, params PageParams) (PaginatedUsersResponse, error) {
@@ -173,9 +189,6 @@ func (r *Repository) UserResources(ctx context.Context, rawID string) (UserResou
 
 	row, err := r.client.User.Query().
 		Where(user.ID(userID)).
-		WithInstances().
-		WithContainers().
-		WithKeypairs().
 		Only(ctx)
 	if err != nil {
 		return UserResourcesResponse{}, err
@@ -212,6 +225,11 @@ func (r *Repository) UserResources(ctx context.Context, rawID string) (UserResou
 		Containers: make([]ContainerResponse, 0, len(containerRows)),
 		Keypairs:   make([]KeypairResponse, 0, len(keypairRows)),
 	}
+	// The user row is fetched without edges; derive the counts from the
+	// already-fetched resource rows instead of loading everything twice.
+	res.User.InstanceCount = len(instanceRows)
+	res.User.ContainerCount = len(containerRows)
+	res.User.KeypairCount = len(keypairRows)
 	for _, item := range instanceRows {
 		res.Instances = append(res.Instances, instanceResponse(item))
 	}

--- a/internal/domain/admin/service.go
+++ b/internal/domain/admin/service.go
@@ -3,6 +3,8 @@ package admin
 import (
 	"context"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -23,7 +25,35 @@ func NewService(repo *Repository, health healthChecker, statusSource instanceSta
 }
 
 func (s *Service) Summary(ctx context.Context) (SummaryResponse, error) {
-	return s.repo.Summary(ctx)
+	counts, err := s.repo.SummaryCounts(ctx)
+	if err != nil {
+		return SummaryResponse{}, err
+	}
+
+	// The DB status is written once at creation and goes stale, so count from
+	// live OpenStack statuses and fall back to the DB status only for
+	// instances missing from the live map — same policy as overlayLiveStatuses.
+	live := s.liveStatuses(ctx)
+	statusCounts := make(map[string]int)
+	for _, row := range counts.Instances {
+		status := row.Status
+		if liveStatus, ok := live[row.ID]; ok && liveStatus != "" {
+			status = liveStatus
+		}
+		status = strings.ToUpper(strings.TrimSpace(status))
+		if status == "" {
+			status = "UNKNOWN"
+		}
+		statusCounts[status]++
+	}
+
+	return SummaryResponse{
+		Users:        counts.Users,
+		Instances:    len(counts.Instances),
+		Containers:   counts.Containers,
+		Keypairs:     counts.Keypairs,
+		StatusCounts: statusCounts,
+	}, nil
 }
 
 func (s *Service) Users(ctx context.Context, rawPage, rawLimit string) (PaginatedUsersResponse, error) {
@@ -71,18 +101,27 @@ func (s *Service) UserResources(ctx context.Context, id string) (UserResourcesRe
 
 // overlayLiveStatuses replaces stale DB statuses with live OpenStack statuses, best-effort.
 func (s *Service) overlayLiveStatuses(ctx context.Context, items []InstanceResponse) {
-	if s.statusSource == nil || len(items) == 0 {
+	if len(items) == 0 {
 		return
 	}
-	statuses, err := s.statusSource.InstanceStatuses(ctx)
-	if err != nil {
-		return
-	}
+	statuses := s.liveStatuses(ctx)
 	for i := range items {
 		if live, ok := statuses[items[i].ID]; ok && live != "" {
 			items[i].Status = live
 		}
 	}
+}
+
+// liveStatuses fetches the live OpenStack status map, best-effort; nil when unavailable.
+func (s *Service) liveStatuses(ctx context.Context) map[string]string {
+	if s.statusSource == nil {
+		return nil
+	}
+	statuses, err := s.statusSource.InstanceStatuses(ctx)
+	if err != nil {
+		return nil
+	}
+	return statuses
 }
 
 func (s *Service) System(ctx context.Context) SystemResponse {
@@ -92,11 +131,22 @@ func (s *Service) System(ctx context.Context) SystemResponse {
 	nsProxyStatus := "unconfigured"
 	httpProxyStatus := "unconfigured"
 	if s.health != nil {
-		openstackStatus = healthStatus(s.health.CheckOpenStack(ctx))
-		storageStatus = healthStatus(s.health.CheckStorage(ctx))
-		sshGatewayStatus = healthStatus(s.health.CheckSSHGateway(ctx))
-		nsProxyStatus = healthStatus(s.health.CheckNSProxy(ctx))
-		httpProxyStatus = healthStatus(s.health.CheckHTTPProxy(ctx))
+		// Each check has its own timeout; run them concurrently so the
+		// endpoint responds in one timeout's worth of time, not five.
+		var wg sync.WaitGroup
+		run := func(target *string, check func(context.Context) error) {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				*target = healthStatus(check(ctx))
+			}()
+		}
+		run(&openstackStatus, s.health.CheckOpenStack)
+		run(&storageStatus, s.health.CheckStorage)
+		run(&sshGatewayStatus, s.health.CheckSSHGateway)
+		run(&nsProxyStatus, s.health.CheckNSProxy)
+		run(&httpProxyStatus, s.health.CheckHTTPProxy)
+		wg.Wait()
 	}
 
 	return SystemResponse{

--- a/internal/domain/apps/service.go
+++ b/internal/domain/apps/service.go
@@ -46,7 +46,7 @@ func (s *Service) RegisterApp(ctx context.Context, ownerID uuid.UUID, instanceID
 		return nil, err
 	}
 
-	saved, err := s.repo.SaveForInstance(ctx, ownerID, instanceID, app)
+	saved, err := s.repo.SaveForInstance(ctx, ownerID, app.InstanceID, app)
 	if err != nil {
 		if errors.Is(err, ErrInstanceNotFound) || errors.Is(err, ErrAppAlreadyExists) {
 			return nil, err

--- a/internal/domain/auth/handler.go
+++ b/internal/domain/auth/handler.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"crypto/hmac"
 	"encoding/base64"
 	"encoding/json"
 	"net"
@@ -34,6 +35,10 @@ const (
 
 	cookieAccessToken  = "access_token"
 	cookieRefreshToken = "refresh_token"
+	cookieOAuthState   = "oauth_state"
+
+	// oauthStateCookieMaxAge는 OAuth state nonce 쿠키의 유효 시간(초)입니다.
+	oauthStateCookieMaxAge = 10 * 60
 
 	defaultFrontendURL = "http://localhost:4173"
 )
@@ -102,7 +107,9 @@ func (h *Handler) Login(c *gin.Context) {
 		redirectOrigin = allowedOrigin
 	}
 
-	c.Redirect(http.StatusTemporaryRedirect, h.Svc.GetGoogleLoginURL(redirectOrigin))
+	loginURL, nonce := h.Svc.GetGoogleLoginURL(redirectOrigin)
+	setOAuthStateCookie(c, nonce)
+	c.Redirect(http.StatusTemporaryRedirect, loginURL)
 }
 
 func (h *Handler) Callback(c *gin.Context) {
@@ -111,6 +118,13 @@ func (h *Handler) Callback(c *gin.Context) {
 		h.handleSSHCallback(c, state)
 		return
 	}
+
+	if !validOAuthStateNonce(c, state) {
+		clearOAuthStateCookie(c)
+		c.JSON(http.StatusUnauthorized, ErrorResponse{Error: ErrInvalidOAuthState.Error()})
+		return
+	}
+	clearOAuthStateCookie(c)
 
 	code := c.Query("code")
 	if code == "" {
@@ -385,6 +399,40 @@ func authCookieSecure() bool {
 func setAuthCookie(c *gin.Context, name, value string, maxAge int) {
 	c.SetSameSite(authCookieSameSite())
 	c.SetCookie(name, value, maxAge, "/", "", authCookieSecure(), true)
+}
+
+// setOAuthStateCookie는 로그인 CSRF 방지를 위해 state nonce를 double-submit
+// 쿠키로 저장합니다. 콜백에서 state 파라미터의 nonce와 비교됩니다.
+func setOAuthStateCookie(c *gin.Context, nonce string) {
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(cookieOAuthState, nonce, oauthStateCookieMaxAge, "/", "", authCookieSecure(), true)
+}
+
+// clearOAuthStateCookie는 콜백 처리 후 state 쿠키를 제거합니다.
+func clearOAuthStateCookie(c *gin.Context) {
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(cookieOAuthState, "", -1, "/", "", authCookieSecure(), true)
+}
+
+// validOAuthStateNonce는 state 파라미터에 인코딩된 nonce가 oauth_state 쿠키
+// 값과 일치하는지 상수 시간 비교로 검증합니다.
+func validOAuthStateNonce(c *gin.Context, raw string) bool {
+	b, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return false
+	}
+
+	var state oauthState
+	if err := json.Unmarshal(b, &state); err != nil || state.Nonce == "" {
+		return false
+	}
+
+	cookieNonce, err := c.Cookie(cookieOAuthState)
+	if err != nil || cookieNonce == "" {
+		return false
+	}
+
+	return hmac.Equal([]byte(state.Nonce), []byte(cookieNonce))
 }
 
 func authCookieSameSite() http.SameSite {

--- a/internal/domain/auth/handler_test.go
+++ b/internal/domain/auth/handler_test.go
@@ -455,6 +455,17 @@ func TestLoginIncludesAllowedRedirectOriginInState(t *testing.T) {
 	if state.Nonce == "" {
 		t.Fatal("expected nonce in state")
 	}
+
+	stateCookie := findCookie(w.Result(), cookieOAuthState)
+	if stateCookie == nil {
+		t.Fatal("expected oauth_state cookie to be set")
+	}
+	if stateCookie.Value != state.Nonce {
+		t.Fatalf("expected oauth_state cookie to match state nonce, got %q vs %q", stateCookie.Value, state.Nonce)
+	}
+	if !stateCookie.HttpOnly || stateCookie.SameSite != http.SameSiteLaxMode {
+		t.Error("oauth_state cookie missing HttpOnly or wrong SameSite")
+	}
 }
 
 func TestLoginRejectsInvalidRedirectOrigin(t *testing.T) {
@@ -660,6 +671,7 @@ func TestCallbackFailureRedirectsToStoredFrontendOrigin(t *testing.T) {
 
 	handler := NewHandler(NewService(&fakeRepo{users: map[string]*User{}}, &oauth2.Config{}, NewTokenService("test-secret")), nil, "")
 	req := httptest.NewRequest(http.MethodGet, "/callback?code=bad-code&state="+url.QueryEscape(rawState), nil)
+	req.AddCookie(&http.Cookie{Name: cookieOAuthState, Value: "test-nonce"})
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = req
@@ -672,6 +684,72 @@ func TestCallbackFailureRedirectsToStoredFrontendOrigin(t *testing.T) {
 	wantLocation := "https://preview-21.frontend.example.com" + pathLoginError
 	if got := w.Header().Get("Location"); got != wantLocation {
 		t.Fatalf("expected redirect %q, got %q", wantLocation, got)
+	}
+}
+
+func TestCallbackRejectsMissingOrMismatchedStateNonce(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	stateBytes, err := json.Marshal(oauthState{Nonce: "expected-nonce"})
+	if err != nil {
+		t.Fatalf("failed to marshal state: %v", err)
+	}
+	rawState := base64.RawURLEncoding.EncodeToString(stateBytes)
+
+	tests := []struct {
+		name        string
+		cookieValue string
+		hasCookie   bool
+	}{
+		{name: "missing cookie", hasCookie: false},
+		{name: "mismatched cookie", cookieValue: "wrong-nonce", hasCookie: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewHandler(NewService(&fakeRepo{users: map[string]*User{}}, &oauth2.Config{}, NewTokenService("test-secret")), nil, "")
+			req := httptest.NewRequest(http.MethodGet, "/callback?code=oauth-code&state="+url.QueryEscape(rawState), nil)
+			if tt.hasCookie {
+				req.AddCookie(&http.Cookie{Name: cookieOAuthState, Value: tt.cookieValue})
+			}
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler.Callback(c)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, w.Code)
+			}
+		})
+	}
+}
+
+func TestCallbackAcceptsMatchingStateNonce(t *testing.T) {
+	t.Setenv(envAuthCookieSecure, "false")
+	gin.SetMode(gin.TestMode)
+
+	handler := NewHandler(NewService(&fakeRepo{users: map[string]*User{}}, &oauth2.Config{}, NewTokenService("test-secret")), nil, "")
+
+	stateBytes, err := json.Marshal(oauthState{Nonce: "matching-nonce"})
+	if err != nil {
+		t.Fatalf("failed to marshal state: %v", err)
+	}
+	rawState := base64.RawURLEncoding.EncodeToString(stateBytes)
+
+	// verifyGoogleCode/ProcessGoogleCallback will still fail on this fake code
+	// (redirect-to-error), but a matching nonce must get past the 401
+	// short-circuit — that's what this test asserts.
+	req := httptest.NewRequest(http.MethodGet, "/callback?code=fake-code&state="+url.QueryEscape(rawState), nil)
+	req.AddCookie(&http.Cookie{Name: cookieOAuthState, Value: "matching-nonce"})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	handler.Callback(c)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Fatalf("matching nonce should not be rejected with 401, got %d body=%s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/domain/auth/oauth_service.go
+++ b/internal/domain/auth/oauth_service.go
@@ -41,11 +41,12 @@ func (s *Service) BuildLoginURL(stateOverride string) string {
 	return s.OauthConfig.AuthCodeURL(state, oauth2.AccessTypeOffline)
 }
 
-// GetGoogleLoginURL은 사용자를 리다이렉트시킬 구글 승인 페이지 URL을 생성합니다.
-func (s *Service) GetGoogleLoginURL(redirectOrigin string) string {
-	// 실제 운영 환경에서는 state를 세션에 저장하고 콜백에서 검증해야 보안상 안전합니다.
-	state := s.generateOAuthState(redirectOrigin)
-	return s.OauthConfig.AuthCodeURL(state, oauth2.AccessTypeOffline)
+// GetGoogleLoginURL은 사용자를 리다이렉트시킬 구글 승인 페이지 URL과, 호출자가
+// double-submit 쿠키로 저장해 콜백에서 검증해야 할 state nonce를 함께 반환합니다.
+func (s *Service) GetGoogleLoginURL(redirectOrigin string) (loginURL, nonce string) {
+	nonce = s.generateState(oauthStateByteLen)
+	state := s.encodeOAuthState(nonce, redirectOrigin)
+	return s.OauthConfig.AuthCodeURL(state, oauth2.AccessTypeOffline), nonce
 }
 
 // verifiedGoogleIdentity는 id_token 검증으로 확인된 사용자 정보입니다.
@@ -146,9 +147,9 @@ func (s *Service) generateState(n int) string {
 	return base64.RawURLEncoding.EncodeToString(b)
 }
 
-func (s *Service) generateOAuthState(redirectOrigin string) string {
+func (s *Service) encodeOAuthState(nonce, redirectOrigin string) string {
 	state := oauthState{
-		Nonce:          s.generateState(oauthStateByteLen),
+		Nonce:          nonce,
 		RedirectOrigin: redirectOrigin,
 	}
 	b, err := json.Marshal(state)

--- a/internal/domain/auth/repository.go
+++ b/internal/domain/auth/repository.go
@@ -38,7 +38,7 @@ func (r *Repository) UpsertUser(ctx context.Context, user *User) error {
 		SetName(user.Name).
 		SetGoogleID(user.GoogleID).
 		SetGoogleAccessToken(googleAccessToken).
-		SetGoogleRefreshToken(googleRefreshToken).
+		SetGoogleRefreshToken(googleRefreshToken). // required column; empty is harmless on insert
 		SetGoogleTokenExpiry(googleExpiry)
 	if user.CurrentRefreshJTI != nil {
 		create = create.SetCurrentRefreshJti(*user.CurrentRefreshJTI)
@@ -48,11 +48,15 @@ func (r *Repository) UpsertUser(ctx context.Context, user *User) error {
 		OnConflict(
 			sql.ConflictColumns(entuser.FieldEmail),
 		).
+		// Google은 최초 동의 시에만 refresh_token을 내려주므로, 재로그인 시 빈 값으로
+		// 기존 값을 덮어쓰지 않도록 non-empty일 때만 갱신합니다.
 		Update(func(u *ent.UserUpsert) {
 			u.SetName(user.Name)
 			u.SetGoogleID(user.GoogleID)
 			u.SetGoogleAccessToken(googleAccessToken)
-			u.SetGoogleRefreshToken(googleRefreshToken)
+			if googleRefreshToken != "" {
+				u.SetGoogleRefreshToken(googleRefreshToken)
+			}
 			u.SetGoogleTokenExpiry(googleExpiry)
 			u.SetUpdatedAt(time.Now())
 			if user.CurrentRefreshJTI != nil {

--- a/internal/domain/auth/repository_test.go
+++ b/internal/domain/auth/repository_test.go
@@ -113,6 +113,65 @@ func TestRepository_UpsertUserWithGoogleAuth(t *testing.T) {
 		}
 	})
 
+	t.Run("재로그인 시 refresh_token이 비어있으면 기존 값을 보존한다", func(t *testing.T) {
+		repo := newTestRepo(t)
+		email := "refresh-preserve@khu.ac.kr"
+
+		if err := repo.UpsertUser(ctx, &User{
+			Email: email,
+			Name:  "유저",
+			GoogleAuth: &GoogleInfo{
+				AccessToken:  "access-1",
+				RefreshToken: "original-refresh-token",
+			},
+		}); err != nil {
+			t.Fatalf("failed to seed user: %v", err)
+		}
+
+		// Google은 최초 동의 이후 재로그인 시 refresh_token을 내려주지 않는다.
+		if err := repo.UpsertUser(ctx, &User{
+			Email: email,
+			Name:  "유저",
+			GoogleAuth: &GoogleInfo{
+				AccessToken:  "access-2",
+				RefreshToken: "",
+			},
+		}); err != nil {
+			t.Fatalf("upsert failed: %v", err)
+		}
+
+		saved, err := repo.FindByEmail(ctx, email)
+		if err != nil || saved == nil {
+			t.Fatalf("FindByEmail failed: %v", err)
+		}
+		if saved.GoogleAuth.RefreshToken != "original-refresh-token" {
+			t.Errorf("expected refresh token to be preserved, got %q", saved.GoogleAuth.RefreshToken)
+		}
+		if saved.GoogleAuth.AccessToken != "access-2" {
+			t.Errorf("expected access token to be updated, got %q", saved.GoogleAuth.AccessToken)
+		}
+
+		// 이후 새 refresh_token을 받으면 정상적으로 갱신된다.
+		if err := repo.UpsertUser(ctx, &User{
+			Email: email,
+			Name:  "유저",
+			GoogleAuth: &GoogleInfo{
+				AccessToken:  "access-3",
+				RefreshToken: "new-refresh-token",
+			},
+		}); err != nil {
+			t.Fatalf("upsert failed: %v", err)
+		}
+
+		saved, err = repo.FindByEmail(ctx, email)
+		if err != nil || saved == nil {
+			t.Fatalf("FindByEmail failed: %v", err)
+		}
+		if saved.GoogleAuth.RefreshToken != "new-refresh-token" {
+			t.Errorf("expected refresh token to be updated to new value, got %q", saved.GoogleAuth.RefreshToken)
+		}
+	})
+
 	t.Run("google tokens are empty when GoogleAuth is nil", func(t *testing.T) {
 		repo := newTestRepo(t)
 

--- a/internal/domain/auth/service.go
+++ b/internal/domain/auth/service.go
@@ -19,6 +19,7 @@ var (
 	ErrInvalidTokenType       = errors.New("invalid token type")
 	ErrUserNotFound           = errors.New("user not found")
 	ErrUserLookupFailed       = errors.New("failed to verify user")
+	ErrInvalidOAuthState      = errors.New("invalid oauth state")
 )
 
 // userRepository는 유저 데이터 접근 인터페이스입니다.

--- a/internal/domain/compute/client.go
+++ b/internal/domain/compute/client.go
@@ -1,6 +1,8 @@
 package compute
 
 import (
+	"errors"
+
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/diagnostics"
@@ -19,6 +21,12 @@ type Client struct {
 
 func NewClient(provider *gophercloud.ProviderClient) *Client {
 	return &Client{provider: provider}
+}
+
+// isServerNotFound는 OpenStack 404 응답 여부를 판별한다.
+func isServerNotFound(err error) bool {
+	var notFound gophercloud.ErrDefault404
+	return errors.As(err, &notFound)
 }
 
 func (c *Client) serviceClient() (*gophercloud.ServiceClient, error) {

--- a/internal/domain/compute/service.go
+++ b/internal/domain/compute/service.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -38,7 +39,14 @@ type Service struct {
 	repo             instanceRepo
 	projectID        string
 	defaultNetworkID string
+
+	flavorMu     sync.Mutex
+	flavorCache  []Flavor
+	flavorExpire time.Time
 }
+
+// flavorCacheTTL — flavor 목록은 거의 정적이라 요청마다 OpenStack에 묻지 않는다.
+const flavorCacheTTL = 5 * time.Minute
 
 var (
 	ErrCreateInstanceNameRequired   = errors.New("name is required")
@@ -57,8 +65,24 @@ func NewService(client computeClient, repo instanceRepo, projectID, defaultNetwo
 	}
 }
 
+// fetchFlavors는 flavor 목록을 TTL 캐시를 거쳐 반환한다.
+func (s *Service) fetchFlavors() ([]Flavor, error) {
+	s.flavorMu.Lock()
+	defer s.flavorMu.Unlock()
+	if time.Now().Before(s.flavorExpire) {
+		return s.flavorCache, nil
+	}
+	raw, err := s.client.FetchFlavors()
+	if err != nil {
+		return nil, err
+	}
+	s.flavorCache = raw
+	s.flavorExpire = time.Now().Add(flavorCacheTTL)
+	return raw, nil
+}
+
 func (s *Service) GetFlavors() ([]FlavorResponse, error) {
-	rawFlavors, err := s.client.FetchFlavors()
+	rawFlavors, err := s.fetchFlavors()
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +95,7 @@ func (s *Service) GetFlavors() ([]FlavorResponse, error) {
 }
 
 func (s *Service) GetAvailableFlavorsWithLimit() ([]AvailableFlavorResponse, error) {
-	rawFlavors, err := s.client.FetchFlavors()
+	rawFlavors, err := s.fetchFlavors()
 	if err != nil {
 		return nil, err
 	}
@@ -81,9 +105,10 @@ func (s *Service) GetAvailableFlavorsWithLimit() ([]AvailableFlavorResponse, err
 		return nil, fmt.Errorf("쿼터 조회 실패: %v", err)
 	}
 
-	remCores := quota.Cores.Limit - quota.Cores.InUse
-	remRAM := quota.RAM.Limit - quota.RAM.InUse
-	remInstances := quota.Instances.Limit - quota.Instances.InUse
+	// Reserved: 빌드 진행 중인 예약분도 이미 소진된 용량이다.
+	remCores := quota.Cores.Limit - quota.Cores.InUse - quota.Cores.Reserved
+	remRAM := quota.RAM.Limit - quota.RAM.InUse - quota.RAM.Reserved
+	remInstances := quota.Instances.Limit - quota.Instances.InUse - quota.Instances.Reserved
 
 	var res []AvailableFlavorResponse
 	for _, f := range rawFlavors {
@@ -183,8 +208,14 @@ func (s *Service) GetInstances(ctx context.Context, ownerID uuid.UUID) ([]Instan
 	return res, nil
 }
 
+// pruneStaleInstances는 목록 스냅샷에 없던 DB 행을 정리한다.
+// 생성 직후 레이스(목록 API 지연)로 살아있는 서버의 소유권 행을 지우면
+// 해당 VM이 API에서 영영 보이지 않게 되므로, 개별 조회로 404를 확인한 뒤에만 삭제한다.
 func (s *Service) pruneStaleInstances(ctx context.Context, ownerID uuid.UUID, staleIDs []string) error {
 	for _, id := range staleIDs {
+		if _, err := s.client.FetchInstance(id); !isServerNotFound(err) {
+			continue
+		}
 		if err := s.repo.DeleteByOpenstackID(ctx, ownerID, id); err != nil {
 			return fmt.Errorf("%w: %v", ErrInstanceOperationFailed, err)
 		}
@@ -264,20 +295,29 @@ func (s *Service) UpdateInstance(ctx context.Context, ownerID uuid.UUID, id stri
 	}
 
 	req = normalizeUpdateInstanceRequest(req)
+	// PATCH 시맨틱: 빈 필드는 기존 값 유지.
+	// ponytail: 빈 문자열로 필드를 비우는 건 불가 — 필요해지면 *string DTO로 전환.
 	if req.Name == "" {
 		req.Name = inst.Name
 	}
-
-	if err := s.repo.UpdateInstanceMetadata(ctx, ownerID, id, req); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInstanceOperationFailed, err)
+	if req.KeyName == "" {
+		req.KeyName = inst.KeyName
+	}
+	if req.Note == "" {
+		req.Note = inst.Note
 	}
 
+	// OpenStack 먼저, DB 나중: 원격 실패 시 DB가 먼저 바뀌어 두 시스템이 어긋나는 것을 막는다.
 	if req.Name != inst.Name {
 		if _, err := s.client.UpdateServerName(id, req.Name); err != nil {
 			log.Printf("CRITICAL: Failed to update OpenStack name for %s: %v", id, err)
 
 			return nil, fmt.Errorf("%w: %v", ErrInstanceOperationFailed, err)
 		}
+	}
+
+	if err := s.repo.UpdateInstanceMetadata(ctx, ownerID, id, req); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInstanceOperationFailed, err)
 	}
 
 	return s.GetInstanceDetail(ctx, ownerID, id)
@@ -357,6 +397,10 @@ func (s *Service) CreateInstance(ctx context.Context, ownerID uuid.UUID, opts Cr
 	}
 
 	if err := s.repo.SaveInstance(ctx, ownerID, inst); err != nil {
+		// 소유권 기록 실패 시 방금 만든 서버를 회수해 고아 VM을 막는다.
+		if delErr := s.client.DeleteServer(server.ID); delErr != nil {
+			log.Printf("CRITICAL: orphaned server %s: DB save failed (%v) and cleanup failed (%v)", server.ID, err, delErr)
+		}
 		return nil, fmt.Errorf("%w: %v", ErrInstanceOperationFailed, err)
 	}
 
@@ -364,7 +408,7 @@ func (s *Service) CreateInstance(ctx context.Context, ownerID uuid.UUID, opts Cr
 }
 
 func (s *Service) fetchFlavorMap() (map[string]FlavorResponse, error) {
-	rawFlavors, err := s.client.FetchFlavors()
+	rawFlavors, err := s.fetchFlavors()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/domain/compute/service.go
+++ b/internal/domain/compute/service.go
@@ -40,9 +40,18 @@ type Service struct {
 	projectID        string
 	defaultNetworkID string
 
-	flavorMu     sync.Mutex
-	flavorCache  []Flavor
-	flavorExpire time.Time
+	flavorMu         sync.Mutex
+	flavorCache      []Flavor
+	flavorExpire     time.Time
+	flavorInflight   *flavorFetch // 콜드 스타트(캐시 비어있음)에서 fetch를 공유하기 위한 핸들
+	flavorRefreshing bool         // 만료된 캐시를 백그라운드에서 갱신 중인지 여부
+}
+
+// flavorFetch는 콜드 스타트 시 동시 호출자들이 하나의 upstream fetch 결과를 공유하기 위한 핸들이다.
+type flavorFetch struct {
+	done   chan struct{}
+	result []Flavor
+	err    error
 }
 
 // flavorCacheTTL — flavor 목록은 거의 정적이라 요청마다 OpenStack에 묻지 않는다.
@@ -66,19 +75,65 @@ func NewService(client computeClient, repo instanceRepo, projectID, defaultNetwo
 }
 
 // fetchFlavors는 flavor 목록을 TTL 캐시를 거쳐 반환한다.
+// 네트워크 호출은 절대 flavorMu를 잡은 채로 하지 않는다: 캐시가 있으면 만료돼도 stale 값을
+// 즉시 돌려주고 갱신은 단일 goroutine에 맡기며(stale-while-revalidate), 캐시가 비어있는
+// 콜드 스타트에서만 한 goroutine이 락 밖에서 fetch하고 나머지는 그 결과를 공유받는다.
 func (s *Service) fetchFlavors() ([]Flavor, error) {
 	s.flavorMu.Lock()
-	defer s.flavorMu.Unlock()
+
 	if time.Now().Before(s.flavorExpire) {
-		return s.flavorCache, nil
+		cache := s.flavorCache
+		s.flavorMu.Unlock()
+		return cache, nil
 	}
+
+	if len(s.flavorCache) > 0 {
+		stale := s.flavorCache
+		if !s.flavorRefreshing {
+			s.flavorRefreshing = true
+			go s.refreshFlavorsStale()
+		}
+		s.flavorMu.Unlock()
+		return stale, nil
+	}
+
+	if fetch := s.flavorInflight; fetch != nil {
+		s.flavorMu.Unlock()
+		<-fetch.done
+		return fetch.result, fetch.err
+	}
+
+	fetch := &flavorFetch{done: make(chan struct{})}
+	s.flavorInflight = fetch
+	s.flavorMu.Unlock()
+
 	raw, err := s.client.FetchFlavors()
-	if err != nil {
-		return nil, err
+
+	s.flavorMu.Lock()
+	if err == nil {
+		s.flavorCache = raw
+		s.flavorExpire = time.Now().Add(flavorCacheTTL)
 	}
-	s.flavorCache = raw
-	s.flavorExpire = time.Now().Add(flavorCacheTTL)
-	return raw, nil
+	s.flavorInflight = nil
+	s.flavorMu.Unlock()
+
+	fetch.result, fetch.err = raw, err
+	close(fetch.done)
+
+	return raw, err
+}
+
+// refreshFlavorsStale은 만료된 캐시를 백그라운드에서 갱신한다. 실패해도 기존 stale 캐시를 유지한다.
+func (s *Service) refreshFlavorsStale() {
+	raw, err := s.client.FetchFlavors()
+
+	s.flavorMu.Lock()
+	if err == nil {
+		s.flavorCache = raw
+		s.flavorExpire = time.Now().Add(flavorCacheTTL)
+	}
+	s.flavorRefreshing = false
+	s.flavorMu.Unlock()
 }
 
 func (s *Service) GetFlavors() ([]FlavorResponse, error) {
@@ -201,8 +256,9 @@ func (s *Service) GetInstances(ctx context.Context, ownerID uuid.UUID) ([]Instan
 			Created:    srv.Created,
 		})
 	}
+	// prune 실패는 non-fatal — 이미 조회한 라이브 목록 res는 그대로 반환한다.
 	if err := s.pruneStaleInstances(ctx, ownerID, staleIDs); err != nil {
-		return nil, err
+		log.Printf("WARN: failed to prune stale instances for owner %s: %v", ownerID, err)
 	}
 
 	return res, nil
@@ -211,17 +267,31 @@ func (s *Service) GetInstances(ctx context.Context, ownerID uuid.UUID) ([]Instan
 // pruneStaleInstances는 목록 스냅샷에 없던 DB 행을 정리한다.
 // 생성 직후 레이스(목록 API 지연)로 살아있는 서버의 소유권 행을 지우면
 // 해당 VM이 API에서 영영 보이지 않게 되므로, 개별 조회로 404를 확인한 뒤에만 삭제한다.
+// staleID별 확인은 서로 독립적이므로 병렬로 처리한다.
 func (s *Service) pruneStaleInstances(ctx context.Context, ownerID uuid.UUID, staleIDs []string) error {
-	for _, id := range staleIDs {
-		if _, err := s.client.FetchInstance(id); !isServerNotFound(err) {
-			continue
-		}
-		if err := s.repo.DeleteByOpenstackID(ctx, ownerID, id); err != nil {
-			return fmt.Errorf("%w: %v", ErrInstanceOperationFailed, err)
-		}
-	}
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
 
-	return nil
+	wg.Add(len(staleIDs))
+	for _, id := range staleIDs {
+		go func(id string) {
+			defer wg.Done()
+			if _, err := s.client.FetchInstance(id); !isServerNotFound(err) {
+				return
+			}
+			if err := s.repo.DeleteByOpenstackID(ctx, ownerID, id); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("%w: %v", ErrInstanceOperationFailed, err)
+				}
+				mu.Unlock()
+			}
+		}(id)
+	}
+	wg.Wait()
+
+	return firstErr
 }
 
 // GetInstanceDetail은 DB(소유권), OpenStack 상태, diagnostics를 병렬로 읽어 조합하여 반환합니다.

--- a/internal/domain/compute/service.go
+++ b/internal/domain/compute/service.go
@@ -267,16 +267,20 @@ func (s *Service) GetInstances(ctx context.Context, ownerID uuid.UUID) ([]Instan
 // pruneStaleInstances는 목록 스냅샷에 없던 DB 행을 정리한다.
 // 생성 직후 레이스(목록 API 지연)로 살아있는 서버의 소유권 행을 지우면
 // 해당 VM이 API에서 영영 보이지 않게 되므로, 개별 조회로 404를 확인한 뒤에만 삭제한다.
-// staleID별 확인은 서로 독립적이므로 병렬로 처리한다.
+// staleID별 확인은 서로 독립적이므로 병렬로 처리하되, stale 행이 비정상적으로
+// 많아도 Nova로의 동시 호출이 폭주하지 않게 상한을 둔다.
 func (s *Service) pruneStaleInstances(ctx context.Context, ownerID uuid.UUID, staleIDs []string) error {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var firstErr error
+	sem := make(chan struct{}, 8)
 
 	wg.Add(len(staleIDs))
 	for _, id := range staleIDs {
 		go func(id string) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			if _, err := s.client.FetchInstance(id); !isServerNotFound(err) {
 				return
 			}

--- a/internal/domain/compute/service_test.go
+++ b/internal/domain/compute/service_test.go
@@ -914,7 +914,7 @@ func TestServiceGetInstances(t *testing.T) {
 		// 모든 staleID 확인이 동시에 진행 중일 때까지 대기한다.
 		deadline := time.After(time.Second)
 		for {
-			if atomic.LoadInt32(&maxInFlight) == int32(len(staleIDs)) {
+			if int(atomic.LoadInt32(&maxInFlight)) == len(staleIDs) {
 				break
 			}
 			select {

--- a/internal/domain/compute/service_test.go
+++ b/internal/domain/compute/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/gophercloud/gophercloud"
 )
 
 var testOwnerID = uuid.New()
@@ -187,6 +188,46 @@ func TestServiceGetFlavors(t *testing.T) {
 		_, err := svc.GetFlavors()
 		if err == nil {
 			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("caches flavors across calls", func(t *testing.T) {
+		calls := 0
+		client := &fakeClient{
+			fetchFlavorsFn: func() ([]Flavor, error) {
+				calls++
+				return []Flavor{{ID: "1", Name: "m1.small"}}, nil
+			},
+		}
+		svc := NewService(client, &fakeRepo{}, "project-1", "")
+		for range 3 {
+			if _, err := svc.GetFlavors(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+		if calls != 1 {
+			t.Fatalf("expected 1 upstream fetch, got %d", calls)
+		}
+	})
+
+	t.Run("does not cache errors", func(t *testing.T) {
+		calls := 0
+		client := &fakeClient{
+			fetchFlavorsFn: func() ([]Flavor, error) {
+				calls++
+				if calls == 1 {
+					return nil, errors.New("upstream error")
+				}
+				return []Flavor{{ID: "1"}}, nil
+			},
+		}
+		svc := NewService(client, &fakeRepo{}, "project-1", "")
+		if _, err := svc.GetFlavors(); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		res, err := svc.GetFlavors()
+		if err != nil || len(res) != 1 {
+			t.Fatalf("expected retry to succeed, got res=%v err=%v", res, err)
 		}
 	})
 }
@@ -610,9 +651,14 @@ func TestServiceCreateInstance(t *testing.T) {
 	})
 
 	t.Run("returns operation failed when repo save errors", func(t *testing.T) {
+		var cleanedUpID string
 		client := &fakeClient{
 			createServerFn: func(opts CreateServerOpts) (*Server, error) {
 				return testServer(map[string]any{}), nil
+			},
+			deleteServerFn: func(id string) error {
+				cleanedUpID = id
+				return nil
 			},
 		}
 		repo := &fakeRepo{
@@ -629,6 +675,9 @@ func TestServiceCreateInstance(t *testing.T) {
 		})
 		if !errors.Is(err, ErrInstanceOperationFailed) {
 			t.Fatalf("expected ErrInstanceOperationFailed, got %v", err)
+		}
+		if cleanedUpID != "server-1" {
+			t.Fatalf("expected orphaned server-1 to be cleaned up, got %q", cleanedUpID)
 		}
 	})
 }
@@ -661,6 +710,9 @@ func TestServiceGetInstances(t *testing.T) {
 						},
 					},
 				}}, nil
+			},
+			fetchInstanceFn: func(id string) (*Server, error) {
+				return nil, gophercloud.ErrDefault404{}
 			},
 			fetchFlavorsFn: func() ([]Flavor, error) {
 				return []Flavor{
@@ -697,13 +749,125 @@ func TestServiceGetInstances(t *testing.T) {
 		}
 		client := &fakeClient{
 			fetchInstancesFn: func() ([]Server, error) { return []Server{}, nil },
-			fetchFlavorsFn:   func() ([]Flavor, error) { return []Flavor{}, nil },
+			fetchInstanceFn: func(id string) (*Server, error) {
+				return nil, gophercloud.ErrDefault404{}
+			},
+			fetchFlavorsFn: func() ([]Flavor, error) { return []Flavor{}, nil },
 		}
 
 		svc := NewService(client, repo, "project-1", "")
 		_, err := svc.GetInstances(ctx, testOwnerID)
 		if !errors.Is(err, ErrInstanceOperationFailed) {
 			t.Fatalf("expected ErrInstanceOperationFailed, got %v", err)
+		}
+	})
+
+	t.Run("keeps DB row when server missing from list snapshot but still exists", func(t *testing.T) {
+		var deletedIDs []string
+		repo := &fakeRepo{
+			listByOwnerFn: func(_ context.Context, _ uuid.UUID) ([]Instance, error) {
+				return []Instance{{OpenstackID: "server-racing"}}, nil
+			},
+			deleteByOpenstackIDFn: func(_ context.Context, _ uuid.UUID, id string) error {
+				deletedIDs = append(deletedIDs, id)
+				return nil
+			},
+		}
+		client := &fakeClient{
+			// 목록 스냅샷에는 없지만 개별 조회로는 살아있는 서버 (생성 직후 레이스)
+			fetchInstancesFn: func() ([]Server, error) { return []Server{}, nil },
+			fetchInstanceFn: func(id string) (*Server, error) {
+				return &Server{ID: id, Status: "BUILD"}, nil
+			},
+			fetchFlavorsFn: func() ([]Flavor, error) { return []Flavor{}, nil },
+		}
+
+		svc := NewService(client, repo, "project-1", "")
+		if _, err := svc.GetInstances(ctx, testOwnerID); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(deletedIDs) != 0 {
+			t.Fatalf("expected no deletion for live server, got %#v", deletedIDs)
+		}
+	})
+
+	t.Run("keeps DB row when per-ID confirm fails transiently", func(t *testing.T) {
+		var deletedIDs []string
+		repo := &fakeRepo{
+			listByOwnerFn: func(_ context.Context, _ uuid.UUID) ([]Instance, error) {
+				return []Instance{{OpenstackID: "server-x"}}, nil
+			},
+			deleteByOpenstackIDFn: func(_ context.Context, _ uuid.UUID, id string) error {
+				deletedIDs = append(deletedIDs, id)
+				return nil
+			},
+		}
+		client := &fakeClient{
+			fetchInstancesFn: func() ([]Server, error) { return []Server{}, nil },
+			fetchInstanceFn: func(id string) (*Server, error) {
+				return nil, errors.New("timeout")
+			},
+			fetchFlavorsFn: func() ([]Flavor, error) { return []Flavor{}, nil },
+		}
+
+		svc := NewService(client, repo, "project-1", "")
+		if _, err := svc.GetInstances(ctx, testOwnerID); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(deletedIDs) != 0 {
+			t.Fatalf("expected no deletion on transient error, got %#v", deletedIDs)
+		}
+	})
+}
+
+func TestServiceUpdateInstance(t *testing.T) {
+	ctx := context.Background()
+	existing := &Instance{OpenstackID: "server-1", Name: "old-name", KeyName: "my-key", Note: "my-note"}
+
+	t.Run("preserves key_name and note when request only sets name", func(t *testing.T) {
+		var captured UpdateInstanceRequest
+		repo := &fakeRepo{
+			findByOpenstackIDFn: func(_ context.Context, _ uuid.UUID, _ string) (*Instance, error) {
+				return existing, nil
+			},
+			updateMetadataFn: func(_ context.Context, _ uuid.UUID, _ string, update UpdateInstanceRequest) error {
+				captured = update
+				return nil
+			},
+		}
+		svc := NewService(&fakeClient{}, repo, "project-1", "")
+		if _, err := svc.UpdateInstance(ctx, testOwnerID, "server-1", UpdateInstanceRequest{Name: "new-name"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := UpdateInstanceRequest{Name: "new-name", KeyName: "my-key", Note: "my-note"}
+		if captured != want {
+			t.Fatalf("expected %+v, got %+v", want, captured)
+		}
+	})
+
+	t.Run("does not touch DB when OpenStack rename fails", func(t *testing.T) {
+		dbTouched := false
+		repo := &fakeRepo{
+			findByOpenstackIDFn: func(_ context.Context, _ uuid.UUID, _ string) (*Instance, error) {
+				return existing, nil
+			},
+			updateMetadataFn: func(_ context.Context, _ uuid.UUID, _ string, _ UpdateInstanceRequest) error {
+				dbTouched = true
+				return nil
+			},
+		}
+		client := &fakeClient{
+			updateServerNameFn: func(id, name string) (*Server, error) {
+				return nil, errors.New("nova down")
+			},
+		}
+		svc := NewService(client, repo, "project-1", "")
+		_, err := svc.UpdateInstance(ctx, testOwnerID, "server-1", UpdateInstanceRequest{Name: "new-name"})
+		if !errors.Is(err, ErrInstanceOperationFailed) {
+			t.Fatalf("expected ErrInstanceOperationFailed, got %v", err)
+		}
+		if dbTouched {
+			t.Fatal("expected DB untouched when OpenStack rename fails")
 		}
 	})
 }

--- a/internal/domain/compute/service_test.go
+++ b/internal/domain/compute/service_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gophercloud/gophercloud"
@@ -228,6 +231,107 @@ func TestServiceGetFlavors(t *testing.T) {
 		res, err := svc.GetFlavors()
 		if err != nil || len(res) != 1 {
 			t.Fatalf("expected retry to succeed, got res=%v err=%v", res, err)
+		}
+	})
+}
+
+func TestServiceFetchFlavorsConcurrency(t *testing.T) {
+	t.Run("cold start: concurrent callers share a single upstream fetch", func(t *testing.T) {
+		var calls int32
+		started := make(chan struct{})
+		var startOnce sync.Once
+		release := make(chan struct{})
+		client := &fakeClient{
+			fetchFlavorsFn: func() ([]Flavor, error) {
+				atomic.AddInt32(&calls, 1)
+				startOnce.Do(func() { close(started) })
+				<-release
+				return []Flavor{{ID: "1"}}, nil
+			},
+		}
+		svc := NewService(client, &fakeRepo{}, "project-1", "")
+
+		const n = 10
+		var wg sync.WaitGroup
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				res, err := svc.GetFlavors()
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if len(res) != 1 || res[0].ID != "1" {
+					t.Errorf("unexpected result: %#v", res)
+				}
+			}()
+		}
+
+		<-started
+		close(release)
+		wg.Wait()
+
+		if got := atomic.LoadInt32(&calls); got != 1 {
+			t.Fatalf("expected exactly 1 upstream fetch, got %d", got)
+		}
+	})
+
+	t.Run("stale cache is served immediately while a single background refresh runs", func(t *testing.T) {
+		var calls int32
+		release := make(chan struct{})
+		client := &fakeClient{
+			fetchFlavorsFn: func() ([]Flavor, error) {
+				if atomic.AddInt32(&calls, 1) == 1 {
+					return []Flavor{{ID: "stale"}}, nil
+				}
+				<-release // 백그라운드 갱신 호출: 검증이 끝날 때까지 대기
+				return []Flavor{{ID: "fresh"}}, nil
+			},
+		}
+		svc := NewService(client, &fakeRepo{}, "project-1", "")
+
+		if _, err := svc.GetFlavors(); err != nil {
+			t.Fatalf("unexpected error priming cache: %v", err)
+		}
+		svc.flavorMu.Lock()
+		svc.flavorExpire = time.Now().Add(-time.Second)
+		svc.flavorMu.Unlock()
+
+		const n = 5
+		var wg sync.WaitGroup
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				res, err := svc.GetFlavors()
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if len(res) != 1 || res[0].ID != "stale" {
+					t.Errorf("expected stale flavor served, got %#v", res)
+				}
+			}()
+		}
+		wg.Wait()
+
+		close(release)
+		deadline := time.After(time.Second)
+		for {
+			svc.flavorMu.Lock()
+			refreshing := svc.flavorRefreshing
+			svc.flavorMu.Unlock()
+			if !refreshing {
+				break
+			}
+			select {
+			case <-deadline:
+				t.Fatal("timed out waiting for background refresh to finish")
+			case <-time.After(time.Millisecond):
+			}
+		}
+
+		if got := atomic.LoadInt32(&calls); got != 2 {
+			t.Fatalf("expected exactly 2 upstream fetches (prime + 1 refresh), got %d", got)
 		}
 	})
 }
@@ -738,7 +842,7 @@ func TestServiceGetInstances(t *testing.T) {
 		}
 	})
 
-	t.Run("returns operation failed when pruning stale DB rows fails", func(t *testing.T) {
+	t.Run("prune failure is non-fatal and still returns the live instance list", func(t *testing.T) {
 		repo := &fakeRepo{
 			listByOwnerFn: func(_ context.Context, _ uuid.UUID) ([]Instance, error) {
 				return []Instance{{OpenstackID: "server-stale"}}, nil
@@ -756,10 +860,71 @@ func TestServiceGetInstances(t *testing.T) {
 		}
 
 		svc := NewService(client, repo, "project-1", "")
-		_, err := svc.GetInstances(ctx, testOwnerID)
-		if !errors.Is(err, ErrInstanceOperationFailed) {
-			t.Fatalf("expected ErrInstanceOperationFailed, got %v", err)
+		res, err := svc.GetInstances(ctx, testOwnerID)
+		if err != nil {
+			t.Fatalf("expected prune failure to be non-fatal, got err: %v", err)
 		}
+		if len(res) != 0 {
+			t.Fatalf("expected empty live instance list, got %#v", res)
+		}
+	})
+
+	t.Run("confirms stale IDs concurrently", func(t *testing.T) {
+		staleIDs := []string{"server-a", "server-b", "server-c"}
+		repo := &fakeRepo{
+			listByOwnerFn: func(_ context.Context, _ uuid.UUID) ([]Instance, error) {
+				instances := make([]Instance, len(staleIDs))
+				for i, id := range staleIDs {
+					instances[i] = Instance{OpenstackID: id}
+				}
+				return instances, nil
+			},
+			deleteByOpenstackIDFn: func(_ context.Context, _ uuid.UUID, _ string) error { return nil },
+		}
+
+		var inFlight int32
+		var maxInFlight int32
+		release := make(chan struct{})
+		client := &fakeClient{
+			fetchInstancesFn: func() ([]Server, error) { return []Server{}, nil },
+			fetchInstanceFn: func(id string) (*Server, error) {
+				cur := atomic.AddInt32(&inFlight, 1)
+				for {
+					prev := atomic.LoadInt32(&maxInFlight)
+					if cur <= prev || atomic.CompareAndSwapInt32(&maxInFlight, prev, cur) {
+						break
+					}
+				}
+				<-release
+				atomic.AddInt32(&inFlight, -1)
+				return nil, gophercloud.ErrDefault404{}
+			},
+			fetchFlavorsFn: func() ([]Flavor, error) { return []Flavor{}, nil },
+		}
+
+		svc := NewService(client, repo, "project-1", "")
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			if _, err := svc.GetInstances(ctx, testOwnerID); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+
+		// 모든 staleID 확인이 동시에 진행 중일 때까지 대기한다.
+		deadline := time.After(time.Second)
+		for {
+			if atomic.LoadInt32(&maxInFlight) == int32(len(staleIDs)) {
+				break
+			}
+			select {
+			case <-deadline:
+				t.Fatalf("expected %d concurrent FetchInstance calls, max seen %d", len(staleIDs), atomic.LoadInt32(&maxInFlight))
+			case <-time.After(time.Millisecond):
+			}
+		}
+		close(release)
+		<-done
 	})
 
 	t.Run("keeps DB row when server missing from list snapshot but still exists", func(t *testing.T) {

--- a/internal/domain/compute/service_test.go
+++ b/internal/domain/compute/service_test.go
@@ -913,10 +913,7 @@ func TestServiceGetInstances(t *testing.T) {
 
 		// 모든 staleID 확인이 동시에 진행 중일 때까지 대기한다.
 		deadline := time.After(time.Second)
-		for {
-			if int(atomic.LoadInt32(&maxInFlight)) == len(staleIDs) {
-				break
-			}
+		for int(atomic.LoadInt32(&maxInFlight)) != len(staleIDs) {
 			select {
 			case <-deadline:
 				t.Fatalf("expected %d concurrent FetchInstance calls, max seen %d", len(staleIDs), atomic.LoadInt32(&maxInFlight))

--- a/internal/domain/storage/client.go
+++ b/internal/domain/storage/client.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -26,6 +27,12 @@ type responseHeaderWriter interface {
 
 func NewClient(provider *gophercloud.ProviderClient) *Client {
 	return &Client{provider: provider}
+}
+
+// isSwiftNotFound는 OpenStack Swift 404 응답 여부를 판별한다.
+func isSwiftNotFound(err error) bool {
+	var notFound gophercloud.ErrDefault404
+	return errors.As(err, &notFound)
 }
 
 func (c *Client) serviceClient() (*gophercloud.ServiceClient, error) {

--- a/internal/domain/storage/handler.go
+++ b/internal/domain/storage/handler.go
@@ -191,8 +191,13 @@ func (h *Handler) DownloadObject(c *gin.Context) {
 	objectName := strings.TrimPrefix(c.Param("key"), "/")
 
 	if err := h.Svc.DownloadObject(c.Request.Context(), id, containerName, objectName, c.Writer); err != nil {
+		// 이미 응답 본문이 흘러나간 뒤라면 JSON 에러를 덧붙이지 않고 스트림을 중단한다.
+		if c.Writer.Written() {
+			_ = c.Error(err)
+			return
+		}
 		switch {
-		case errors.Is(err, ErrContainerNotFound):
+		case errors.Is(err, ErrContainerNotFound), errors.Is(err, ErrObjectNotFound):
 			c.JSON(http.StatusNotFound, api.ErrorResponse{Error: err.Error()})
 		default:
 			c.JSON(http.StatusInternalServerError, api.ErrorResponse{Error: err.Error()})
@@ -240,7 +245,7 @@ func (h *Handler) DeleteObject(c *gin.Context) {
 
 	if err := h.Svc.DeleteObject(c.Request.Context(), id, containerName, objectName); err != nil {
 		switch {
-		case errors.Is(err, ErrContainerNotFound):
+		case errors.Is(err, ErrContainerNotFound), errors.Is(err, ErrObjectNotFound):
 			c.JSON(http.StatusNotFound, api.ErrorResponse{Error: err.Error()})
 		default:
 			c.JSON(http.StatusInternalServerError, api.ErrorResponse{Error: err.Error()})

--- a/internal/domain/storage/handler_test.go
+++ b/internal/domain/storage/handler_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/gophercloud/gophercloud"
 
 	"github.com/KHU-RETURN/rcp-server/internal/api"
 	"github.com/KHU-RETURN/rcp-server/internal/domain/auth"
@@ -497,6 +498,62 @@ func TestHandlerDownloadObject(t *testing.T) {
 			t.Fatalf("unexpected body: %q", w.Body.String())
 		}
 	})
+
+	t.Run("returns 404 when object does not exist in Swift", func(t *testing.T) {
+		client := &fakeStorageClient{
+			downloadObjectFn: func(_, _ string, _ io.Writer) error {
+				return gophercloud.ErrDefault404{}
+			},
+		}
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return &Container{Name: "my-bucket", OpenstackName: testContainerUUID}, nil
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, api.BasePath+"/storage/containers/my-bucket/objects/missing.txt", nil)
+		w := httptest.NewRecorder()
+		r := gin.New()
+		v1 := r.Group(api.BasePath)
+		withTestUser(v1)
+		newTestHandler(client, repo).InitRoutes(v1)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("does not append JSON error after body streaming started", func(t *testing.T) {
+		// 이미 200 응답 본문이 흘러나간 뒤 다운로드가 실패하면
+		// JSON 에러로 스트림을 오염시키지 않아야 한다.
+		client := &fakeStorageClient{
+			downloadObjectFn: func(_, _ string, w io.Writer) error {
+				_, _ = w.Write([]byte("partial content"))
+				return errors.New("stream error: connection reset")
+			},
+		}
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return &Container{Name: "my-bucket", OpenstackName: testContainerUUID}, nil
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, api.BasePath+"/storage/containers/my-bucket/objects/hello.txt", nil)
+		w := httptest.NewRecorder()
+		r := gin.New()
+		v1 := r.Group(api.BasePath)
+		withTestUser(v1)
+		newTestHandler(client, repo).InitRoutes(v1)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 (headers already sent), got %d", w.Code)
+		}
+		if w.Body.String() != "partial content" {
+			t.Fatalf("expected only partial content in body, got %q", w.Body.String())
+		}
+	})
 }
 
 func TestHandlerArchiveObjects(t *testing.T) {
@@ -581,6 +638,31 @@ func TestHandlerDeleteObject(t *testing.T) {
 
 		if w.Code != http.StatusNoContent {
 			t.Fatalf("expected 204, got %d", w.Code)
+		}
+	})
+
+	t.Run("returns 404 when object does not exist in Swift", func(t *testing.T) {
+		client := &fakeStorageClient{
+			deleteObjectFn: func(_, _ string) error {
+				return gophercloud.ErrDefault404{}
+			},
+		}
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return &Container{Name: "my-bucket", OpenstackName: testContainerUUID}, nil
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodDelete, api.BasePath+"/storage/containers/my-bucket/objects/missing.txt", nil)
+		w := httptest.NewRecorder()
+		r := gin.New()
+		v1 := r.Group(api.BasePath)
+		withTestUser(v1)
+		newTestHandler(client, repo).InitRoutes(v1)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
 		}
 	})
 }

--- a/internal/domain/storage/repository.go
+++ b/internal/domain/storage/repository.go
@@ -25,6 +25,11 @@ func (r *Repository) Save(ctx context.Context, ownerID uuid.UUID, c *Container) 
 		SetName(c.Name).
 		Save(ctx)
 	if err != nil {
+		// (owner, name) 유니크 인덱스 위반은 동시 생성 경쟁에서 이미 같은 이름이
+		// 저장됐다는 뜻이므로 도메인 에러로 변환한다.
+		if ent.IsConstraintError(err) {
+			return ErrContainerAlreadyExists
+		}
 		return err
 	}
 	c.CreatedAt = row.CreatedAt
@@ -32,19 +37,32 @@ func (r *Repository) Save(ctx context.Context, ownerID uuid.UUID, c *Container) 
 }
 
 func (r *Repository) FindByName(ctx context.Context, ownerID uuid.UUID, name string) (*Container, error) {
-	row, err := r.client.Container.Query().
-		Where(
-			entcontainer.Name(name),
-			entcontainer.HasOwnerWith(entuser.ID(ownerID)),
-		).Only(ctx)
+	row, err := r.findByNameQuery(ownerID, name).Only(ctx)
 	if err != nil {
-		if ent.IsNotFound(err) {
+		switch {
+		case ent.IsNotFound(err):
 			return nil, nil
+		case ent.IsNotSingular(err):
+			// 유니크 인덱스 도입 이전에 생성된 중복 행이 남아 있어도
+			// 조회가 실패하지 않도록 첫 행으로 폴백한다.
+			row, err = r.findByNameQuery(ownerID, name).First(ctx)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, err
 		}
-		return nil, err
 	}
 	c := entToContainer(row)
 	return &c, nil
+}
+
+func (r *Repository) findByNameQuery(ownerID uuid.UUID, name string) *ent.ContainerQuery {
+	return r.client.Container.Query().
+		Where(
+			entcontainer.Name(name),
+			entcontainer.HasOwnerWith(entuser.ID(ownerID)),
+		)
 }
 
 func (r *Repository) ListByOwner(ctx context.Context, ownerID uuid.UUID) ([]Container, error) {

--- a/internal/domain/storage/repository_test.go
+++ b/internal/domain/storage/repository_test.go
@@ -1,0 +1,73 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/KHU-RETURN/rcp-server/ent"
+	"github.com/KHU-RETURN/rcp-server/ent/enttest"
+
+	_ "github.com/KHU-RETURN/rcp-server/internal/infrastructure/database"
+)
+
+func newRepoTestClient(t *testing.T) (*ent.Client, uuid.UUID) {
+	t.Helper()
+	c := enttest.Open(t, "sqlite3", "file:"+t.Name()+"?mode=memory&cache=shared&_pragma=foreign_keys(1)")
+	t.Cleanup(func() { _ = c.Close() })
+
+	user := c.User.Create().SetEmail("storage@khu.ac.kr").SetName("storage").
+		SetGoogleID("storage-gid").
+		SetGoogleAccessToken("").SetGoogleRefreshToken("").
+		SetGoogleTokenExpiry(time.Unix(0, 0).UTC()).SaveX(context.Background())
+	return c, user.ID
+}
+
+func TestRepositorySaveDuplicateName(t *testing.T) {
+	ctx := context.Background()
+	c, ownerID := newRepoTestClient(t)
+	repo := NewRepository(c)
+
+	if err := repo.Save(ctx, ownerID, &Container{OpenstackName: uuid.New(), Name: "my-bucket"}); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	// 같은 소유자가 같은 이름으로 다시 저장하면 (owner, name) 유니크 인덱스에 걸려
+	// ErrContainerAlreadyExists로 매핑되어야 한다.
+	err := repo.Save(ctx, ownerID, &Container{OpenstackName: uuid.New(), Name: "my-bucket"})
+	if !errors.Is(err, ErrContainerAlreadyExists) {
+		t.Fatalf("expected ErrContainerAlreadyExists, got %v", err)
+	}
+
+	// 중복 행이 없으므로 FindByName은 not-singular 없이 단일 행을 반환해야 한다.
+	found, err := repo.FindByName(ctx, ownerID, "my-bucket")
+	if err != nil {
+		t.Fatalf("FindByName: %v", err)
+	}
+	if found == nil || found.Name != "my-bucket" {
+		t.Fatalf("unexpected container: %+v", found)
+	}
+}
+
+func TestRepositorySaveSameNameDifferentOwner(t *testing.T) {
+	ctx := context.Background()
+	c, ownerID := newRepoTestClient(t)
+	repo := NewRepository(c)
+
+	other := c.User.Create().SetEmail("other@khu.ac.kr").SetName("other").
+		SetGoogleID("other-gid").
+		SetGoogleAccessToken("").SetGoogleRefreshToken("").
+		SetGoogleTokenExpiry(time.Unix(0, 0).UTC()).SaveX(ctx)
+
+	// 유니크 인덱스는 (owner, name) 조합에만 적용되므로
+	// 다른 소유자는 같은 이름의 컨테이너를 가질 수 있어야 한다.
+	if err := repo.Save(ctx, ownerID, &Container{OpenstackName: uuid.New(), Name: "shared-name"}); err != nil {
+		t.Fatalf("save for first owner: %v", err)
+	}
+	if err := repo.Save(ctx, other.ID, &Container{OpenstackName: uuid.New(), Name: "shared-name"}); err != nil {
+		t.Fatalf("save for second owner: %v", err)
+	}
+}

--- a/internal/domain/storage/service.go
+++ b/internal/domain/storage/service.go
@@ -16,6 +16,7 @@ var (
 	ErrContainerNotFound      = errors.New("container not found")
 	ErrContainerNotEmpty      = errors.New("container not empty, use force=true to delete all")
 	ErrContainerAlreadyExists = errors.New("container name already in use")
+	ErrObjectNotFound         = errors.New("object not found")
 	ErrObjectPrefixNotFound   = errors.New("object prefix not found")
 	ErrStorageOperationFailed = errors.New("storage operation failed")
 )
@@ -64,7 +65,13 @@ func (s *Service) CreateContainer(ctx context.Context, ownerID uuid.UUID, name s
 
 	c := &Container{OpenstackName: openstackName, Name: name}
 	if err := s.repo.Save(ctx, ownerID, c); err != nil {
-		if delErr := s.client.DeleteContainer(openstackName.String()); delErr != nil {
+		delErr := s.client.DeleteContainer(openstackName.String())
+		// 동시 생성 경쟁에서 유니크 제약에 걸린 경우: 방금 만든 Swift 컨테이너를
+		// 정리(best-effort)하고 이름 충돌로 응답한다.
+		if errors.Is(err, ErrContainerAlreadyExists) {
+			return nil, ErrContainerAlreadyExists
+		}
+		if delErr != nil {
 			return nil, fmt.Errorf("%w: %v (cleanup failed: %v)", ErrStorageOperationFailed, err, delErr)
 		}
 		return nil, fmt.Errorf("%w: %v", ErrStorageOperationFailed, err)
@@ -93,7 +100,12 @@ func (s *Service) DeleteContainer(ctx context.Context, ownerID uuid.UUID, name s
 
 	objs, err := s.client.ListObjects(c.OpenstackName.String())
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrStorageOperationFailed, err)
+		// Swift 컨테이너가 이미 삭제된 경우(이전 삭제 시도가 DB 정리 전에 실패한 재시도 등)에는
+		// 남은 DB 행 정리만 이어서 진행한다.
+		if !isSwiftNotFound(err) {
+			return fmt.Errorf("%w: %v", ErrStorageOperationFailed, err)
+		}
+		objs = nil
 	}
 
 	if len(objs) > 0 {
@@ -109,7 +121,7 @@ func (s *Service) DeleteContainer(ctx context.Context, ownerID uuid.UUID, name s
 		}
 	}
 
-	if err := s.client.DeleteContainer(c.OpenstackName.String()); err != nil {
+	if err := s.client.DeleteContainer(c.OpenstackName.String()); err != nil && !isSwiftNotFound(err) {
 		return fmt.Errorf("%w: %v", ErrStorageOperationFailed, err)
 	}
 
@@ -148,6 +160,9 @@ func (s *Service) DownloadObject(ctx context.Context, ownerID uuid.UUID, contain
 		return err
 	}
 	if err := s.client.DownloadObject(c.OpenstackName.String(), objectName, w); err != nil {
+		if isSwiftNotFound(err) {
+			return ErrObjectNotFound
+		}
 		return fmt.Errorf("%w: %v", ErrStorageOperationFailed, err)
 	}
 	return nil
@@ -207,6 +222,9 @@ func (s *Service) DeleteObject(ctx context.Context, ownerID uuid.UUID, container
 		return err
 	}
 	if err := s.client.DeleteObject(c.OpenstackName.String(), objectName); err != nil {
+		if isSwiftNotFound(err) {
+			return ErrObjectNotFound
+		}
 		return fmt.Errorf("%w: %v", ErrStorageOperationFailed, err)
 	}
 	return nil

--- a/internal/domain/storage/service.go
+++ b/internal/domain/storage/service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"sort"
 	"strings"
 
@@ -69,6 +70,9 @@ func (s *Service) CreateContainer(ctx context.Context, ownerID uuid.UUID, name s
 		// 동시 생성 경쟁에서 유니크 제약에 걸린 경우: 방금 만든 Swift 컨테이너를
 		// 정리(best-effort)하고 이름 충돌로 응답한다.
 		if errors.Is(err, ErrContainerAlreadyExists) {
+			if delErr != nil {
+				log.Printf("CRITICAL: orphaned swift container %s: name conflict and cleanup failed (%v)", openstackName, delErr)
+			}
 			return nil, ErrContainerAlreadyExists
 		}
 		if delErr != nil {

--- a/internal/domain/storage/service_test.go
+++ b/internal/domain/storage/service_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/gophercloud/gophercloud"
 )
 
 var (
@@ -161,6 +162,31 @@ func TestServiceCreateContainer(t *testing.T) {
 			t.Fatalf("expected ErrContainerAlreadyExists, got %v", err)
 		}
 	})
+
+	t.Run("maps unique constraint violation on save to ErrContainerAlreadyExists and cleans up Swift", func(t *testing.T) {
+		// 동시 생성 경쟁: FindByName은 통과했지만 Save가 유니크 제약에 걸린 경우.
+		var cleanedUp string
+		client := &fakeStorageClient{
+			deleteContainerFn: func(name string) error {
+				cleanedUp = name
+				return nil
+			},
+		}
+		repo := &fakeContainerRepo{
+			saveFn: func(_ context.Context, _ uuid.UUID, _ *Container) error {
+				return ErrContainerAlreadyExists
+			},
+		}
+
+		svc := NewService(client, repo)
+		_, err := svc.CreateContainer(ctx, testOwnerID, "my-bucket")
+		if !errors.Is(err, ErrContainerAlreadyExists) {
+			t.Fatalf("expected ErrContainerAlreadyExists, got %v", err)
+		}
+		if cleanedUp == "" {
+			t.Fatal("expected orphaned Swift container to be cleaned up")
+		}
+	})
 }
 
 func TestServiceListContainers(t *testing.T) {
@@ -286,6 +312,37 @@ func TestServiceDeleteContainer(t *testing.T) {
 		err := svc.DeleteContainer(ctx, testOwnerID, "missing", false)
 		if !errors.Is(err, ErrContainerNotFound) {
 			t.Fatalf("expected ErrContainerNotFound, got %v", err)
+		}
+	})
+
+	t.Run("deletes DB row even when Swift container is already gone", func(t *testing.T) {
+		// 이전 삭제 시도에서 Swift 컨테이너만 지워지고 DB 정리가 실패한 경우,
+		// 재시도가 404에 막히지 않고 수렴해야 한다.
+		client := &fakeStorageClient{
+			listObjectsFn: func(_ string) ([]ObjectInfo, error) {
+				return nil, gophercloud.ErrDefault404{}
+			},
+			deleteContainerFn: func(_ string) error {
+				return gophercloud.ErrDefault404{}
+			},
+		}
+		var deletedFromDB string
+		repo := &fakeContainerRepo{
+			findByNameFn: func(_ context.Context, _ uuid.UUID, _ string) (*Container, error) {
+				return existingContainer, nil
+			},
+			deleteFn: func(_ context.Context, _ uuid.UUID, name string) error {
+				deletedFromDB = name
+				return nil
+			},
+		}
+
+		svc := NewService(client, repo)
+		if err := svc.DeleteContainer(ctx, testOwnerID, "my-bucket", false); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deletedFromDB != "my-bucket" {
+			t.Fatalf("expected DB delete with name, got %q", deletedFromDB)
 		}
 	})
 }

--- a/internal/infrastructure/database/database.go
+++ b/internal/infrastructure/database/database.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
+	entsql "entgo.io/ent/dialect/sql"
 	_ "github.com/lib/pq"
 	"modernc.org/sqlite"
 
@@ -35,9 +37,14 @@ func NewEntClient(cfg Config) (*ent.Client, error) {
 }
 
 func OpenEntClient(cfg Config) (*ent.Client, error) {
-	client, err := ent.Open(cfg.Driver, cfg.DSN)
+	drv, err := entsql.Open(cfg.Driver, cfg.DSN)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
-	return client, nil
+	// sqlite는 파일 단위 write lock이라 writer 커넥션을 1개로 제한해
+	// 풀 내부 경쟁으로 인한 SQLITE_BUSY를 막는다 (읽기 전용 DSN은 제외).
+	if cfg.Driver == "sqlite3" && !strings.Contains(cfg.DSN, "mode=ro") {
+		drv.DB().SetMaxOpenConns(1)
+	}
+	return ent.NewClient(ent.Driver(drv)), nil
 }

--- a/internal/schema/container.go
+++ b/internal/schema/container.go
@@ -6,6 +6,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 	"github.com/google/uuid"
 )
 
@@ -26,5 +27,12 @@ func (Container) Fields() []ent.Field {
 func (Container) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("owner", User.Type).Ref("containers").Required().Unique(),
+	}
+}
+
+func (Container) Indexes() []ent.Index {
+	return []ent.Index{
+		// 같은 소유자가 동일한 이름의 컨테이너를 동시에 생성해도 중복 행이 생기지 않도록 보장한다.
+		index.Fields("name").Edges("owner").Unique(),
 	}
 }

--- a/internal/server/cors.go
+++ b/internal/server/cors.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"log"
 	"net/http"
 	"os"
 	"regexp"
@@ -16,7 +17,7 @@ const (
 
 func corsMiddleware() gin.HandlerFunc {
 	allowedOrigins := parseAllowedOrigins(os.Getenv(envAllowedOrigins))
-	allowedOriginPattern := strings.TrimSpace(os.Getenv(envAllowedOriginPattern))
+	allowedOriginPattern := compileAllowedOriginPattern(os.Getenv(envAllowedOriginPattern))
 
 	return func(c *gin.Context) {
 		origin := strings.TrimSpace(c.GetHeader("Origin"))
@@ -50,14 +51,28 @@ func parseAllowedOrigins(rawOrigins string) map[string]bool {
 	return allowedOrigins
 }
 
-func isOriginAllowed(origin string, allowedOrigins map[string]bool, allowedOriginPattern string) bool {
+// compileAllowedOriginPattern compiles the pattern once at middleware setup
+// instead of on every request. An invalid pattern is logged and treated as
+// unset rather than failing startup.
+func compileAllowedOriginPattern(raw string) *regexp.Regexp {
+	pattern := strings.TrimSpace(raw)
+	if pattern == "" {
+		return nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		log.Printf("invalid %s: %v", envAllowedOriginPattern, err)
+		return nil
+	}
+	return re
+}
+
+func isOriginAllowed(origin string, allowedOrigins map[string]bool, allowedOriginPattern *regexp.Regexp) bool {
 	if allowedOrigins[origin] {
 		return true
 	}
-	if allowedOriginPattern == "" {
+	if allowedOriginPattern == nil {
 		return false
 	}
-
-	matched, err := regexp.MatchString(allowedOriginPattern, origin)
-	return err == nil && matched
+	return allowedOriginPattern.MatchString(origin)
 }

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -229,6 +229,32 @@ func TestRouterCORSRejectsUnconfiguredOrigin(t *testing.T) {
 	}
 }
 
+func TestRouterCORSInvalidPatternTreatedAsUnset(t *testing.T) {
+	setGinMode(t, gin.TestMode)
+	t.Setenv(envAllowedOriginPattern, "(unterminated")
+
+	router := NewRouter(&App{
+		Access:  &access.Handler{},
+		Auth:    &auth.Handler{},
+		Compute: &compute.Handler{},
+		Storage: &storage.Handler{},
+	})
+
+	req := httptest.NewRequest(http.MethodOptions, api.BasePath+"/auth/me", nil)
+	req.Header.Set("Origin", "https://frontend.example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no allowed origin for invalid pattern, got %q", got)
+	}
+}
+
 func setGinMode(t *testing.T, mode string) {
 	t.Helper()
 


### PR DESCRIPTION
 ## 요약
  코드베이스 전체를 멀티 에이전트 감사(도메인별 리뷰어 4개)로 점검하고, 발견 사항을 코드로 검증·수정한 뒤 적대적 리뷰로 재검증했습니다. 총 14 커밋.

  **보안 / 정확성**
  - **auth**: OAuth `state` nonce를 생성만 하고 검증하지 않아 로그인 CSRF가 가능했음. `/auth/oauth/google`에서 SameSite=Lax 더블서밋 쿠키로 검증하도록 수정 (ssh-gateway 플로우는 영향 없음). 재로그인 시 Google이 빈 refresh_token을 반환하면 저장된 토큰을 빈 값으로 덮어쓰던 문제도 수정.
  - **access**: 키페어 삭제가 수렴하도록 수정 — OpenStack 404가 발생해도 DB 행이 영구히 삭제 불가능한 상태로 남지 않음.
  - **apps/storage**: `RegisterApp`이 트림 검증까지 해놓고 정작 조회는 트림 전 instance ID로 하던 문제 수정. `CreateContainer`가 이름 충돌 경로에서 Swift 정리 실패를 무음 처리하던 것을 로깅하도록 수정.

  **안정성**
  - **sqlite**: 여러 프로세스(api 읽기·쓰기, 게이트웨이 읽기 전용)가 DB 파일을 공유하는데 `busy_timeout`이 없어 동시 쓰기가 즉시 SQLITE_BUSY 500으로 튀던 문제. 세 기본 DSN 모두에 

**안정성**
- **sqlite**: 여러 프로세스(api 읽기·쓰기, 게이트웨이 읽기 전용)가 DB 파일을 공유하는데 `busy_timeout`이 없어 동시 쓰기가 즉시 SQLITE_BUSY 500으로 튀던 문제. 세 기본 DSN 모두에 `busy_timeout(5000)` 추가, writer 커넥션 풀을 1개로 제한.
- **api**: gin 기본 서버에 타임아웃이 전혀 없었음(Slowloris 취약). `ReadHeaderTimeout`/`IdleTimeout` 명시. `Read/WriteTimeout`은 웹소켓 콘솔 연결 유지를 위해 의도적으로 제외.
- **ssh-gateway**: accept 에러 발생 시(EMFILE 등) 백오프 없이 100% CPU로 무한 루프 돌던 문제 → ns-proxy와 동일한 지수 백오프 적용. 동시 접속 제한 세마포어 추가 (`RCP_SSH_GW_MAX_CONNS`, 기본 256).
- **게이트웨이**: SOCKS5 CONNECT 핸드셰이크가 내부적으로 `context.Background()`로 동작해 데드라인이 전혀 걸리지 않았음 — ns-proxy가 멈추면 요청당 고루틴+fd가 영구 누수. 요청 데드라인 또는 15초로 제한하고 핸드셰이크 성공 후 해제.

**성능**
- **compute**: 플레이버 캐시가 뮤텍스를 잡은 채 OpenStack 왕복을 수행해 TTL 만료 시마다 모든 인스턴스 목록/상세 요청이 직렬화되던 문제 → stale-while-revalidate + 콜드 스타트 singleflight로 개선. stale 행 정리는 병렬화(Nova 동시 호출 8개로 제한)하고 비치명화해, 정리 실패가 정상적인 목록 조회를 500으로 만들지 않도록 수정.
- **CORS**: 오리진 패턴 정규식을 요청마다 재컴파일하던 것을 기동 시 1회 컴파일로 변경.

## 사전 리뷰
최종 diff에 대한 독립 컨텍스트 적대적 리뷰: **P1 없음**. P2 1건(prune 무제한 fan-out)은 `a99a4f3`에서 수정. 수용한 트레이드오프:
- Admin `SummaryCounts`의 쿼리 병렬화는 writer 커넥션 1개인 sqlite에서는 이득이 없음(Postgres에서는 여전히 유효). 무해함.
- 한 브라우저에서 로그인을 동시에 두 번 시도하면 `oauth_state` 쿠키가 서로 덮어써져 먼저 연 탭의 콜백이 401을 받고 재시도해야 함. 더블서밋 쿠키 패턴의 표준적인 동작.

## 후속 과제 (이 PR에 포함하지 않음)
- `GET /internal/ssh/authorized-keys`는 형제 엔드포인트와 달리 HMAC 인증이 없음 — VM 이미지 갱신과 함께 조율해서 수정해야 하며, 서버만 고치면 배포된 SSH 콘솔이 깨짐.
- OpenStack 클라이언트 메서드가 `context.Context`를 받지 않아 클라이언트가 연결을 끊어도 진행 중인 호출을 취소할 수 없음(5분 HTTP 타임아웃으로만 제한). 인터페이스 전체 리팩터링 필요.
- 객체 목록 / 관리자 사용자 리소스 엔드포인트에 페이지네이션 없음 (API 계약 변경 필요).

## 테스트
- [x] `go build ./...`, `go vet ./...` 통과
- [x] `go test ./... -race` — 전 패키지 통과
- [x] 신규 테스트: OAuth nonce 수락/거부, refresh token 보존, 키페어 삭제 수렴, 플레이버 캐시 singleflight + stale 제공(-race 5회 반복 안정), ssh-gateway MaxConns 거부, 설정 기본값
