### PR TITLE
ci: CD 사각지대 및 동시 실행 레이스 정리

### DIFF
--- a/.github/workflows/deploy-app-gateway.yml
+++ b/.github/workflows/deploy-app-gateway.yml
@@ -6,7 +6,9 @@ on:
     paths:
       - "cmd/app-gateway/**"
       - "internal/infrastructure/database/**"
+      - "internal/infrastructure/http/**"
       - "internal/infrastructure/openstack/**"
+      - "internal/schema/**"
       - "internal/utils/**"
       - "ent/**"
       - "go.mod"
@@ -15,6 +17,10 @@ on:
       - "deploy/systemd/app-gateway.service"
       - ".github/workflows/deploy-app-gateway.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-ns-proxy.yml
+++ b/.github/workflows/deploy-ns-proxy.yml
@@ -6,9 +6,15 @@ on:
     paths:
       - 'cmd/ns-proxy/**'
       - 'internal/utils/**'
+      - 'go.mod'
+      - 'go.sum'
       - 'deploy/systemd/ns-proxy.service'
       - '.github/workflows/deploy-ns-proxy.yml'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-ssh-gateway.yml
+++ b/.github/workflows/deploy-ssh-gateway.yml
@@ -5,15 +5,24 @@ on:
     branches: [ "main" ]
     paths:
       - "cmd/ssh-gateway/**"
-      - "internal/domain/access/ssh_*.go"
-      - "internal/domain/access/ssh_*_test.go"
-      - "internal/domain/access/hostkey_test.go"
-      - "internal/utils/**"
+      - "internal/api/**"
+      - "internal/domain/access/**"
+      - "internal/domain/auth/**"
       - "internal/infrastructure/database/**"
+      - "internal/infrastructure/http/**"
       - "internal/infrastructure/openstack/**"
+      - "internal/schema/**"
+      - "internal/utils/**"
+      - "ent/**"
+      - "go.mod"
+      - "go.sum"
       - "deploy/systemd/ssh-gateway.service.example"
       - ".github/workflows/deploy-ssh-gateway.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,19 @@ name: Go CD Pipeline
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - "cmd/api/**"
+      - "internal/**"
+      - "ent/**"
+      - "go.mod"
+      - "go.sum"
+      - "deploy/systemd/rcp-server.service"
+      - ".github/workflows/deploy.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/go-pr-quality.yml
+++ b/.github/workflows/go-pr-quality.yml
@@ -108,6 +108,9 @@ jobs:
           - name: api
             output: server
             target: ./cmd/api/main.go
+          - name: app-gateway
+            output: app-gateway
+            target: ./cmd/app-gateway
           - name: ns-proxy
             output: ns-proxy
             target: ./cmd/ns-proxy


### PR DESCRIPTION
### PR CI
- build 매트릭스에 `app-gateway` 추가 — 지금까지 app-gateway는 PR에서 컴파일 검증이 안 됐고, 깨져도 배포 시점에야 발견됐음

### CD 워크플로우 (deploy*.yml)

**paths 필터 정리** — `go list -deps` 로 각 바이너리의 실제 의존 패키지를 뽑아서 필터를 맞춤
- `deploy.yml`: 필터가 아예 없어서 README 수정에도 api 서버가 재빌드·재시작되던 것 수정. 수동 배포용 `workflow_dispatch`도 추가
- `deploy-app-gateway.yml`: `internal/infrastructure/http`, `internal/schema` 누락 보완
- `deploy-ssh-gateway.yml`: `internal/api`, `internal/domain/auth`, `ent`, `go.mod/sum` 등 누락 다수 보완 (기존엔 `ssh_*.go` 글롭만 걸려 있어 공용 코드 변경 시 배포가 스킵됨)
- `deploy-ns-proxy.yml`: `go.mod/sum` 추가

**concurrency 추가** — 4개 CD 워크플로우 전부에 `group: ${{ github.workflow }}` + `cancel-in-progress: false`
- main에 연달아 푸시하면 deploy가 동시에 돌아 옛 커밋이 새 커밋을 덮어쓸 수 있던 레이스 제거. 이제 같은 워크플로우는 순차 큐잉됨

## 검증
- `go build ./cmd/app-gateway` 통과
- 워크플로우 YAML 파싱 확인

## 참고
- 서로 **다른** CD 워크플로우 간 동시 실행은 그대로 둠 — 현재는 서로 다른 파일/서비스만 만져서 충돌 없고, group을 공유하면 GitHub이 대기 run을 취소해 배포가 스킵될 수 있음
- CD가 PR CI 통과를 기다리지 않는 건 코드가 아니라 브랜치 보호 설정 문제 — main에 required status checks 걸려 있는지 별도 확인 필요
